### PR TITLE
Add CPMS post card payment confirmation logic

### DIFF
--- a/src/server/controllers/payment.controller.js
+++ b/src/server/controllers/payment.controller.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-use-before-define */
 import PaymentService from './../services/payment.service';
 import PenaltyService from './../services/penalty.service';
 import CpmsService from './../services/cpms.service';
@@ -222,6 +223,23 @@ export const confirmPayment = async (req, res) => {
   }
 };
 
+export const confirmGroupPayment = async (req, res) => {
+  const paymentCode = req.params.payment_code;
+  const penaltyType = req.params.type;
+  const receiptReference = req.query.receipt_reference;
+  const penaltyGroup = await penaltyGroupService.getByPaymentCode(paymentCode);
+  const confirmResp = await cpmsService.confirmPayment(receiptReference, penaltyType);
+  const payload = buildGroupPaymentPayload(
+    paymentCode,
+    receiptReference,
+    penaltyType,
+    penaltyGroup,
+    confirmResp,
+  );
+  await paymentService.recordGroupPayment(payload);
+  res.redirect(`${config.urlRoot}/payment-code/${paymentCode}/${penaltyType}/receipt`);
+};
+
 export const reversePayment = async (req, res) => {
   // Get penalty details
   try {
@@ -286,3 +304,22 @@ export const reversePayment = async (req, res) => {
   }
   return true;
 };
+
+function buildGroupPaymentPayload(paymentCode, receiptReference, type, penaltyGroup, confirmResp) {
+  const amountForType = penaltyGroup.penaltyGroupDetails.splitAmounts
+    .find(a => a.type === type).amount;
+  return {
+    PaymentCode: paymentCode,
+    PenaltyType: type,
+    PaymentDetail: {
+      PaymentMethod: 'CNP',
+      PaymentRef: receiptReference,
+      AuthCode: confirmResp.data.auth_code,
+      PaymentAmount: amountForType,
+      PaymentDate: Math.floor(Date.now() / 1000),
+    },
+    PenaltyIds: penaltyGroup.penaltyDetails
+      .find(penaltiesOfType => penaltiesOfType.type === type).penalties
+      .map(penalties => `${penalties.reference}_${type}`),
+  };
+}

--- a/src/server/routes.js
+++ b/src/server/routes.js
@@ -24,6 +24,7 @@ router.get('/payment-code/:payment_code/payment', paymentCodeController.validate
 router.get('/payment-code/:payment_code/:type/payment', paymentCodeController.validatePaymentCode, paymentController.renderGroupPaymentPage);
 router.post('/payment-code/:payment_code/payment', paymentCodeController.validatePaymentCode, paymentController.makePayment);
 router.get('/payment-code/:payment_code/confirmPayment', paymentController.confirmPayment);
+router.get('/payment-code/:payment_code/:type/confirmGroupPayment', paymentController.confirmGroupPayment);
 router.post('/payment-code/:payment_code/reversePayment', paymentController.reversePayment);
 router.get('/payment-code/:payment_code/:type/details', paymentCodeController.getPenaltyGroupBreakdownForType);
 

--- a/src/server/services/cpms.service.js
+++ b/src/server/services/cpms.service.js
@@ -18,8 +18,9 @@ export default class PaymentService {
 
   createCardNotPresentGroupTransaction(penGrpId, penGrpDetails, type, penalties, redirectUrl) {
     const total = penGrpDetails.splitAmounts.find(a => a.type === type).amount;
-    return this.httpClient.post('groupCardNotPresentPayment/', JSON.stringify({
+    return this.httpClient.post('groupCardPayment/', {
       TotalAmount: total,
+      PaymentMethod: 'CNP',
       VehicleRegistration: penGrpDetails.registrationNumber,
       PenaltyGroupId: penGrpId,
       PenaltyType: type,
@@ -29,7 +30,7 @@ export default class PaymentService {
         PenaltyAmount: p.amount,
         VehicleRegistration: p.vehicleReg,
       })),
-    }));
+    });
   }
 
   createCashTransaction(vehicleReg, penaltyReference, penaltyType, amount, slipNumber) {

--- a/src/server/services/payment.service.js
+++ b/src/server/services/payment.service.js
@@ -9,8 +9,8 @@ export default class PaymentService {
     return this.httpClient.post('payments/', details);
   }
 
-  recordGroupPayment() {
-    return this;
+  recordGroupPayment(details) {
+    return this.httpClient.post('groupPayments/', details);
   }
 
   reversePayment(paymentId) {

--- a/src/server/services/payment.service.js
+++ b/src/server/services/payment.service.js
@@ -9,6 +9,10 @@ export default class PaymentService {
     return this.httpClient.post('payments/', details);
   }
 
+  recordGroupPayment() {
+    return this;
+  }
+
   reversePayment(paymentId) {
     return this.httpClient.delete(`payments/${paymentId}`);
   }

--- a/test/services/cpms.service.spec.js
+++ b/test/services/cpms.service.spec.js
@@ -14,8 +14,9 @@ describe('CPMS Service', () => {
     beforeEach(() => {
       httpClientStub = sinon.stub(HttpClient.prototype, 'post');
       httpClientStub
-        .withArgs('groupCardNotPresentPayment/', JSON.stringify({
+        .withArgs('groupCardPayment/', {
           TotalAmount: 120,
+          PaymentMethod: 'CNP',
           VehicleRegistration: '11DDD',
           PenaltyGroupId: '5624r2wupfs',
           PenaltyType: 'FPN',
@@ -32,7 +33,7 @@ describe('CPMS Service', () => {
               VehicleRegistration: '11DDD',
             },
           ],
-        }))
+        })
         .resolves('resolved value');
     });
     it('should return POST promise from groupCardNotPresent endpoint', async () => {


### PR DESCRIPTION
* Very similar to `rsp-public-portal`
* Check for `801` code in response payload indicating the payment was successful
* Call payment service to record the payment when successful and return to unimplemented receipt page
* Render the failed payment page if anything goes wrong