### PR TITLE
Add templates and payment endpoints for penalty group non-card payment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11124,7 +11124,6 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.21.tgz",
       "integrity": "sha512-j96bAh4otsgj3lKydm3K7kdtA3iKf2m6MY2iSYCzCm5a1zmHo1g+aK3068dDEeocLZQIS9kU8bsdQHLqEvgW0A==",
-      "dev": true,
       "requires": {
         "moment": ">= 2.9.0"
       }

--- a/src/server/controllers/payment.controller.js
+++ b/src/server/controllers/payment.controller.js
@@ -192,7 +192,12 @@ const bindArgsForPaymentType = (partialFn, paymentType, body) => {
     case 'cash':
       return partialFn.bind(cpmsService, body.slipNumber);
     case 'cheque':
-      const { slipNumber, chequeDate, chequeNumber, nameOnCheque } = body;
+      const {
+        slipNumber,
+        chequeDate,
+        chequeNumber,
+        nameOnCheque,
+      } = body;
       return partialFn.bind(cpmsService, slipNumber, chequeDate, chequeNumber, nameOnCheque);
     case 'postal-order':
       return partialFn.bind(cpmsService);
@@ -268,6 +273,8 @@ export const renderGroupPaymentPage = async (req, res) => {
   switch (paymentType) {
     case 'cash':
       return res.render('payment/groupCash', penaltyGroupWithPaymentType);
+    case 'cheque':
+      return res.render('payment/groupCheque', penaltyGroupWithPaymentType);
     default:
       return res.redirect(`${config.urlRoot}/?invalidPaymentCode`);
   }

--- a/src/server/controllers/payment.controller.js
+++ b/src/server/controllers/payment.controller.js
@@ -147,7 +147,7 @@ export const makeGroupPayment = async (req, res) => {
 
     const paymentMethodStrategy = paymentMethodMappings[paymentType];
 
-    const partialTransactionCreationFunction = paymentMethodStrategy.transactionCreationFunction.bind(
+    const partialCreationFunction = paymentMethodStrategy.transactionCreationFunction.bind(
       cpmsService,
       paymentCode,
       penaltyGroup.penaltyGroupDetails,
@@ -157,7 +157,7 @@ export const makeGroupPayment = async (req, res) => {
     );
 
     const finalTransactionCreationFunction = bindArgsForPaymentType(
-      partialTransactionCreationFunction,
+      partialCreationFunction,
       paymentType,
       req.body,
     );

--- a/src/server/controllers/payment.controller.js
+++ b/src/server/controllers/payment.controller.js
@@ -143,6 +143,7 @@ export const makeGroupPayment = async (req, res) => {
     const paymentMethodMappings = {
       cash: { transactionCreationFunction: cpmsService.createGroupCashTransaction, paymentRecordMethod: 'CASH' },
       cheque: { transactionCreationFunction: cpmsService.createGroupChequeTransaction, paymentRecordMethod: 'CHEQUE' },
+      postal: { transactionCreationFunction: cpmsService.createGroupPostalOrderTransaction, paymentRecordMethod: 'POSTAL_ORDER' },
     };
 
     const paymentMethodStrategy = paymentMethodMappings[paymentType];
@@ -199,8 +200,8 @@ const bindArgsForPaymentType = (partialFn, paymentType, body) => {
         nameOnCheque,
       } = body;
       return partialFn.bind(cpmsService, slipNumber, chequeDate, chequeNumber, nameOnCheque);
-    case 'postal-order':
-      return partialFn.bind(cpmsService);
+    case 'postal':
+      return partialFn.bind(cpmsService, body.slipNumber, body.postalOrderNumber);
     default:
       return partialFn;
   }
@@ -275,6 +276,8 @@ export const renderGroupPaymentPage = async (req, res) => {
       return res.render('payment/groupCash', penaltyGroupWithPaymentType);
     case 'cheque':
       return res.render('payment/groupCheque', penaltyGroupWithPaymentType);
+    case 'postal':
+      return res.render('payment/groupPostalOrder', penaltyGroupWithPaymentType);
     default:
       return res.redirect(`${config.urlRoot}/?invalidPaymentCode`);
   }

--- a/src/server/routes.js
+++ b/src/server/routes.js
@@ -24,6 +24,7 @@ router.get('/payment-code/:payment_code', paymentCodeController.getPenaltyDetail
 router.get('/payment-code/:payment_code/payment', paymentCodeController.validatePaymentCode, paymentController.renderPaymentPage);
 router.get('/payment-code/:payment_code/:type/payment', paymentCodeController.validatePaymentCode, paymentController.renderGroupPaymentPage);
 router.post('/payment-code/:payment_code/payment', paymentCodeController.validatePaymentCode, paymentController.makePayment);
+router.post('/payment-code/:payment_code/:type/payment', paymentController.makeGroupPayment);
 router.get('/payment-code/:payment_code/confirmPayment', paymentController.confirmPayment);
 router.get('/payment-code/:payment_code/:type/confirmGroupPayment', paymentController.confirmGroupPayment);
 router.post('/payment-code/:payment_code/reversePayment', paymentController.reversePayment);

--- a/src/server/services/cpms.service.js
+++ b/src/server/services/cpms.service.js
@@ -146,7 +146,26 @@ export default class PaymentService {
     slipNumber,
     postalOrderNumber,
   ) {
-    return this.httpClient.post('groupPayment/', {});
+    const total = penGrpDetails.splitAmounts.find(a => a.type === type).amount;
+    const penaltiesOfType = penalties.find(p => p.type === type).penalties;
+    const payload = {
+      TotalAmount: total,
+      PaymentMethod: 'CASH',
+      VehicleRegistration: penGrpDetails.registrationNumber,
+      PenaltyGroupId: penGrpId,
+      PenaltyType: type,
+      RedirectUrl: redirectUrl,
+      ReceiptDate: new Date().toISOString().split('T')[0],
+      SlipNumber: slipNumber,
+      PostalOrderNumber: postalOrderNumber,
+      BatchNumber: 1,
+      Penalties: penaltiesOfType.map(p => ({
+        PenaltyReference: p.reference,
+        PenaltyAmount: p.amount,
+        VehicleRegistration: p.vehicleReg,
+      })),
+    };
+    return this.httpClient.post('groupPayment/', payload);
   }
 
   confirmPayment(receiptReference, penaltyType) {

--- a/src/server/services/cpms.service.js
+++ b/src/server/services/cpms.service.js
@@ -45,7 +45,7 @@ export default class PaymentService {
     });
   }
 
-  createGroupCashTransaction(penGrpId, penGrpDetails, type, penalties, slipNumber, redirectUrl) {
+  createGroupCashTransaction(penGrpId, penGrpDetails, type, penalties, redirectUrl, slipNumber) {
     const total = penGrpDetails.splitAmounts.find(a => a.type === type).amount;
     const penaltiesOfType = penalties.find(p => p.type === type).penalties;
 
@@ -66,6 +66,10 @@ export default class PaymentService {
       })),
     };
     return this.httpClient.post('groupPayment/', payload);
+  }
+
+  createGroupChequeTransaction(penGrpId, penGrpDetails, type, penalties, redirectUrl) {
+    return this.httpClient;
   }
 
   createChequeTransaction(

--- a/src/server/services/cpms.service.js
+++ b/src/server/services/cpms.service.js
@@ -68,8 +68,29 @@ export default class PaymentService {
     return this.httpClient.post('groupPayment/', payload);
   }
 
-  createGroupChequeTransaction(penGrpId, penGrpDetails, type, penalties, redirectUrl) {
-    return this.httpClient;
+  createGroupChequeTransaction(penGrpId, penGrpDetails, type, penalties, redirectUrl, slipNumber, chequeNumber, chequeDate, nameOnCheque) {
+    const total = penGrpDetails.splitAmounts.find(a => a.type === type).amount;
+    const penaltiesOfType = penalties.find(p => p.type === type).penalties;
+    const payload = {
+      TotalAmount: total,
+      PaymentMethod: 'CASH',
+      VehicleRegistration: penGrpDetails.registrationNumber,
+      PenaltyGroupId: penGrpId,
+      PenaltyType: type,
+      RedirectUrl: redirectUrl,
+      ReceiptDate: new Date().toISOString().split('T')[0],
+      SlipNumber: slipNumber,
+      BatchNumber: 1,
+      ChequeNumber: chequeNumber,
+      ChequeDate: chequeDate,
+      NameOnCheque: nameOnCheque,
+      Penalties: penaltiesOfType.map(p => ({
+        PenaltyReference: p.reference,
+        PenaltyAmount: p.amount,
+        VehicleRegistration: p.vehicleReg,
+      })),
+    };
+    return this.httpClient.post('groupPayment/', payload);
   }
 
   createChequeTransaction(

--- a/src/server/services/cpms.service.js
+++ b/src/server/services/cpms.service.js
@@ -68,7 +68,17 @@ export default class PaymentService {
     return this.httpClient.post('groupPayment/', payload);
   }
 
-  createGroupChequeTransaction(penGrpId, penGrpDetails, type, penalties, redirectUrl, slipNumber, chequeNumber, chequeDate, nameOnCheque) {
+  createGroupChequeTransaction(
+    penGrpId,
+    penGrpDetails,
+    type,
+    penalties,
+    redirectUrl,
+    slipNumber,
+    chequeNumber,
+    chequeDate,
+    nameOnCheque,
+  ) {
     const total = penGrpDetails.splitAmounts.find(a => a.type === type).amount;
     const penaltiesOfType = penalties.find(p => p.type === type).penalties;
     const payload = {

--- a/src/server/services/cpms.service.js
+++ b/src/server/services/cpms.service.js
@@ -18,7 +18,7 @@ export default class PaymentService {
 
   createCardNotPresentGroupTransaction(penGrpId, penGrpDetails, type, penalties, redirectUrl) {
     const total = penGrpDetails.splitAmounts.find(a => a.type === type).amount;
-    return this.httpClient.post('groupCardPayment/', {
+    return this.httpClient.post('groupPayment/', {
       TotalAmount: total,
       PaymentMethod: 'CNP',
       VehicleRegistration: penGrpDetails.registrationNumber,
@@ -43,6 +43,29 @@ export default class PaymentService {
       batch_number: 1,
       vehicle_reg: vehicleReg,
     });
+  }
+
+  createGroupCashTransaction(penGrpId, penGrpDetails, type, penalties, slipNumber, redirectUrl) {
+    const total = penGrpDetails.splitAmounts.find(a => a.type === type).amount;
+    const penaltiesOfType = penalties.find(p => p.type === type).penalties;
+
+    const payload = {
+      TotalAmount: total,
+      PaymentMethod: 'CASH',
+      VehicleRegistration: penGrpDetails.registrationNumber,
+      PenaltyGroupId: penGrpId,
+      PenaltyType: type,
+      RedirectUrl: redirectUrl,
+      SlipNumber: slipNumber,
+      ReceiptDate: new Date().toISOString().split('T')[0],
+      BatchNumber: 1,
+      Penalties: penaltiesOfType.map(p => ({
+        PenaltyReference: p.reference,
+        PenaltyAmount: p.amount,
+        VehicleRegistration: p.vehicleReg,
+      })),
+    };
+    return this.httpClient.post('groupPayment/', payload);
   }
 
   createChequeTransaction(

--- a/src/server/services/cpms.service.js
+++ b/src/server/services/cpms.service.js
@@ -68,6 +68,24 @@ export default class PaymentService {
     return this.httpClient.post('groupPayment/', payload);
   }
 
+  createChequeTransaction(
+    vehicleReg, penaltyReference, penaltyType, amount,
+    slipNumber, chequeDate, chequeNumber, nameOnCheque,
+  ) {
+    return this.httpClient.post('chequePayment/', {
+      penalty_reference: penaltyReference,
+      penalty_type: penaltyType,
+      penalty_amount: amount,
+      slip_number: slipNumber,
+      receipt_date: new Date().toISOString().split('T')[0],
+      batch_number: 1,
+      cheque_date: chequeDate,
+      cheque_number: chequeNumber,
+      name_on_cheque: nameOnCheque,
+      vehicle_reg: vehicleReg,
+    });
+  }
+
   createGroupChequeTransaction(
     penGrpId,
     penGrpDetails,
@@ -103,24 +121,6 @@ export default class PaymentService {
     return this.httpClient.post('groupPayment/', payload);
   }
 
-  createChequeTransaction(
-    vehicleReg, penaltyReference, penaltyType, amount,
-    slipNumber, chequeDate, chequeNumber, nameOnCheque,
-  ) {
-    return this.httpClient.post('chequePayment/', {
-      penalty_reference: penaltyReference,
-      penalty_type: penaltyType,
-      penalty_amount: amount,
-      slip_number: slipNumber,
-      receipt_date: new Date().toISOString().split('T')[0],
-      batch_number: 1,
-      cheque_date: chequeDate,
-      cheque_number: chequeNumber,
-      name_on_cheque: nameOnCheque,
-      vehicle_reg: vehicleReg,
-    });
-  }
-
   createPostalOrderTransaction(
     vehicleReg, penaltyReference, penaltyType, amount,
     slipNumber, postalOrderNumber,
@@ -135,6 +135,18 @@ export default class PaymentService {
       postal_order_number: postalOrderNumber,
       vehicle_reg: vehicleReg,
     });
+  }
+
+  createGroupPostalOrderTransaction(
+    penGrpId,
+    penGrpDetails,
+    type,
+    penalties,
+    redirectUrl,
+    slipNumber,
+    postalOrderNumber,
+  ) {
+    return this.httpClient.post('groupPayment/', {});
   }
 
   confirmPayment(receiptReference, penaltyType) {

--- a/src/server/views/layouts/partials/header.njk
+++ b/src/server/views/layouts/partials/header.njk
@@ -8,6 +8,9 @@
         </a>
       </div>
     </div>
+  <a href="/logout" title="Logout">
+    {{ components.heading(text='Logout', tag='h3', size='small', extraClass='userInfo') }}
+  </a>
   {{ components.heading(text='Logged in as '+settings.rsp_user.name, tag='h3', size='small', extraClass='userInfo') }}
 </header>
 

--- a/src/server/views/payment/groupCash.njk
+++ b/src/server/views/payment/groupCash.njk
@@ -61,7 +61,6 @@
           </tbody>
         </table>
 
-        <p>
         {% call components.form(action="", method="POST") %}
           <input type="hidden" name="paymentCode" value="{{ paymentCode }}">
           <input type="hidden" name="paymentType" value="cash">

--- a/src/server/views/payment/groupCash.njk
+++ b/src/server/views/payment/groupCash.njk
@@ -43,8 +43,8 @@
 
         <table>
           <thead>
-            <td>Penalty Reference</td>
-            <td>Amount</td>
+            <th>Penalty Reference</th>
+            <th>Amount</th>
           </thead>
           <tbody>
             {% for penaltyTypeGroup in penaltyDetails %}

--- a/src/server/views/payment/groupCash.njk
+++ b/src/server/views/payment/groupCash.njk
@@ -5,7 +5,7 @@
     { text: 'Home', url: '/' },
     { text: 'Payment Code', url: '/' },
     { text: 'Penalty Details', url: '/payment-code/'+paymentCode },
-    { text: 'Payment by Cash' }
+    { text: 'Payment by cash' }
   ]
 %}
 

--- a/src/server/views/payment/groupCash.njk
+++ b/src/server/views/payment/groupCash.njk
@@ -35,7 +35,8 @@
             </tr>
             <tr>
               <td>Status:</td>
-              <td>{{ paymentStatus }}</td>
+              {% set statusClass = 'confirmed' if paymentStatus == 'PAID' else 'unconfirmed' %}
+              <td><span class='{{statusClass}}'>{{ paymentStatus }}</span></td>
           </tbody>
         </table>
 

--- a/src/server/views/payment/groupCheque.njk
+++ b/src/server/views/payment/groupCheque.njk
@@ -1,0 +1,81 @@
+{% extends 'layouts/default.layout.njk' %}
+
+{% set pageTitle = 'DVSA Road Side Payment Portal' %}
+{% set pageBreadcrumbItems = [
+    { text: 'Home', url: '/' },
+    { text: 'Payment Code', url: '/' },
+    { text: 'Penalty Details', url: '/payment-code/'+paymentCode },
+    { text: 'Payment by Cash' }
+  ]
+%}
+
+{% block content %}
+  
+  {% call components.gridRow() %}
+    {% call components.columnTwoThirds() %}
+      {{ components.heading(text="Payment by cash", tag="h1", size="large") }}
+        <table class="details">
+          <caption class="heading-medium">Penalty Details</caption>
+          <tbody>
+            <tr>
+              <td>Payment Code:</td>
+              <td>{{ paymentCode }}</td> 
+            </tr>
+            <tr>
+              <td>Vehicle registration:</td>
+              <td>{{ penaltyGroupDetails.registrationNumber }}</td>
+            </tr>
+            <tr>
+              <td>Date issued:</td>
+              <td>{{ penaltyGroupDetails.date }}</td>
+            </tr>
+            <tr>
+              <td>Location:</td>
+              <td>{{ penaltyGroupDetails.location }}</td>
+            </tr>
+            <tr>
+              <td>Status:</td>
+              <td>{{ paymentStatus }}</td>
+          </tbody>
+        </table>
+
+        <br />
+
+        <table>
+          <thead>
+            <th>Penalty Reference</th>
+            <th>Amount</th>
+          </thead>
+          <tbody>
+            {% for penaltyTypeGroup in penaltyDetails %}
+              {% if penaltyTypeGroup.type == paymentPenaltyType %}
+                {% for penalty in penaltyTypeGroup.penalties %}
+                  <tr>
+                    <td>{{ penalty.formattedReference }}</td>
+                    <td>&pound;{{ penalty.amount }}</td>
+                  </tr>
+                {% endfor %}
+              {% endif %}
+            {% endfor %}
+          </tbody>
+        </table>
+
+        <p>
+        {% call components.form(action="", method="POST") %}
+						<input type="hidden" name="reference" value="{{ reference }}">
+						<input type="hidden" name="type" value="{{ type }}">
+						<input type="hidden" name="amount" value="{{ amount }}">
+						<input type="hidden" name="paymentCode" value="{{ paymentCode }}">
+            <input type="hidden" name="vehicleReg" value="{{ vehicleReg }}">
+            <input type="hidden" name="paymentType" value="cheque">
+
+          {{ components.heading(text="Payment details ", tag="h3", size="medium") }}
+          <p>{{ components.field(id="chequeDate", type="date", label="Date on cheque", required=true) }}</p>
+          <p>{{ components.field(id="chequeNumber", type="number", label= "Cheque number", required=true) }}</p>
+          <p>{{ components.field(id="nameOnCheque", label="Name on cheque", required=true) }}</p>
+          <p>{{ components.field(id="slipNumber", type="number", label="Paying in slip number", required=true) }}</p>
+          {{ components.button(text="Confirm payment", type="submit") }}
+        {%- endcall %}
+    {%- endcall %}
+  {%- endcall %}
+{% endblock %}

--- a/src/server/views/payment/groupCheque.njk
+++ b/src/server/views/payment/groupCheque.njk
@@ -5,7 +5,7 @@
     { text: 'Home', url: '/' },
     { text: 'Payment Code', url: '/' },
     { text: 'Penalty Details', url: '/payment-code/'+paymentCode },
-    { text: 'Payment by Cash' }
+    { text: 'Payment by Cheque' }
   ]
 %}
 
@@ -35,7 +35,8 @@
             </tr>
             <tr>
               <td>Status:</td>
-              <td>{{ paymentStatus }}</td>
+              {% set statusClass = 'confirmed' if paymentStatus == 'PAID' else 'unconfirmed' %}
+              <td><span class='{{statusClass}}'>{{ paymentStatus }}</span></td>
           </tbody>
         </table>
 

--- a/src/server/views/payment/groupCheque.njk
+++ b/src/server/views/payment/groupCheque.njk
@@ -5,7 +5,7 @@
     { text: 'Home', url: '/' },
     { text: 'Payment Code', url: '/' },
     { text: 'Penalty Details', url: '/payment-code/'+paymentCode },
-    { text: 'Payment by Cheque' }
+    { text: 'Payment by cheque' }
   ]
 %}
 
@@ -13,7 +13,7 @@
   
   {% call components.gridRow() %}
     {% call components.columnTwoThirds() %}
-      {{ components.heading(text="Payment by cash", tag="h1", size="large") }}
+      {{ components.heading(text="Payment by cheque", tag="h1", size="large") }}
         <table class="details">
           <caption class="heading-medium">Penalty Details</caption>
           <tbody>

--- a/src/server/views/payment/groupPostalOrder.njk
+++ b/src/server/views/payment/groupPostalOrder.njk
@@ -67,12 +67,10 @@
 						<input type="hidden" name="amount" value="{{ amount }}">
 						<input type="hidden" name="paymentCode" value="{{ paymentCode }}">
             <input type="hidden" name="vehicleReg" value="{{ vehicleReg }}">
-            <input type="hidden" name="paymentType" value="cheque">
+            <input type="hidden" name="paymentType" value="postal">
 
           {{ components.heading(text="Payment details ", tag="h3", size="medium") }}
-          <p>{{ components.field(id="chequeDate", type="date", label="Date on cheque", required=true) }}</p>
-          <p>{{ components.field(id="chequeNumber", type="number", label= "Cheque number", required=true) }}</p>
-          <p>{{ components.field(id="nameOnCheque", label="Name on cheque", required=true) }}</p>
+          <p>{{ components.field(id="postalOrderNumber", type="number", label= "Postal order number", required=true) }}</p>
           <p>{{ components.field(id="slipNumber", type="number", label="Paying in slip number", required=true) }}</p>
           {{ components.button(text="Confirm payment", type="submit") }}
         {%- endcall %}

--- a/src/server/views/payment/groupPostalOrder.njk
+++ b/src/server/views/payment/groupPostalOrder.njk
@@ -5,7 +5,7 @@
     { text: 'Home', url: '/' },
     { text: 'Payment Code', url: '/' },
     { text: 'Penalty Details', url: '/payment-code/'+paymentCode },
-    { text: 'Payment by Cheque' }
+    { text: 'Payment by postal order' }
   ]
 %}
 
@@ -13,7 +13,7 @@
   
   {% call components.gridRow() %}
     {% call components.columnTwoThirds() %}
-      {{ components.heading(text="Payment by cash", tag="h1", size="large") }}
+      {{ components.heading(text="Payment by postal order", tag="h1", size="large") }}
         <table class="details">
           <caption class="heading-medium">Penalty Details</caption>
           <tbody>

--- a/src/server/views/payment/multiPaymentReceipt.njk
+++ b/src/server/views/payment/multiPaymentReceipt.njk
@@ -43,12 +43,44 @@
               </strong>
             </td>
           </tr>
-          <tr>
-            <td>Authorisation code</td>
-            <td>
-              <strong>{{ paymentDetails.Payments[paymentType].AuthCode }}</strong>
-            </td>
-          </tr>
+          {% if paymentDetails.Payments[paymentType].PaymentMethod == 'CNP' %}
+            <tr>
+              <td>Payment method</td>
+              <td><strong>Card (internal portal)</td>
+            </tr>
+            <tr>
+              <td>Authorisation code</td>
+              <td>
+                <strong>{{ paymentDetails.Payments[paymentType].AuthCode }}</strong>
+              </td>
+            </tr>
+          {% elif paymentDetails.Payments[paymentType].PaymentMethod == 'CARD' %}
+            <tr>
+              <td>Payment method</td>
+              <td><strong>Card (public portal)</td>
+            </tr>
+            <tr>
+              <td>Authorisation code</td>
+              <td>
+                <strong>{{ paymentDetails.Payments[paymentType].AuthCode }}</strong>
+              </td>
+            </tr>
+          {% elif paymentDetails.Payments[paymentType].PaymentMethod == 'CASH' %}
+            <tr>
+              <td>Payment method</td>
+              <td><strong>Cash</strong></td>
+            </tr>
+          {% elif paymentDetails.Payments[paymentType].PaymentMethod == 'CHEQUE' %}
+            <tr>
+              <td>Payment method</td>
+              <td><strong>Cheque</strong></td>
+            </tr>
+          {% elif paymentDetails.Payments[paymentType].PaymentMethod == 'POSTAL_ORDER' %}
+            <tr>
+              <td>Payment method</td>
+              <td><strong>Postal order</strong></td>
+            </tr>
+          {% endif %}
         </tbody>
       </table>
 

--- a/src/server/views/payment/penaltyGroupTypeBreakdown.njk
+++ b/src/server/views/payment/penaltyGroupTypeBreakdown.njk
@@ -3,24 +3,21 @@
 {% set pageTitle = 'DVSA Road Side Payment Portal' %}
 {% set pageBreadcrumbItems = [
     { text: 'Home', url: '/' },
-    { text: 'Payment Code', url: '/payment-code' },
-    { text: 'Penalty Details' }
+    { text: paymentCode, url: '/payment-code/' + paymentCode },
+    { text: 'Fines' }
   ] 
 %}
   
 {% block content %}
   {% call components.gridRow() %}
     {% call components.columnTwoThirds() %}
-      {{ components.heading(text='Pay fixed penalties and immobilisation fees', tag='h1', size='xlarge') }}
-      <h3 class="heading-medium">
         {% if penaltyType == 'FPN' %}
-          Pay fixed penalties
+          {{ components.heading(text='Pay fixed penalties', tag='h1', size='xlarge') }}
         {% elif penaltyType == 'CDN' %}
-          Pay court deposits
+          {{ components.heading(text='Pay court deposits', tag='h1', size='xlarge') }}
         {% elif penaltyType == 'IM' %}
-          Pay immobilisation fee
+          {{ components.heading(text='Pay immobilisation fee', tag='h1', size='xlarge') }}
         {% endif %}
-      </h3>
       {# Payment summary table #}
       <table>
         <thead>
@@ -57,22 +54,14 @@
           {{ components.radio(text='Cheque', value='cheque', id='pay-by-cheque', name='paymentType') }}
           {{ components.radio(text='Postal Order', value='postal', id='pay-by-postal', name='paymentType') }}
         {%- endcall %}
-        {{ components.button(text='Continue to payment', type='submit') }}
+        {% if penaltyType == 'FPN' %}
+          {{ components.button(text='Pay fixed penalties', type='submit') }}
+        {% elif penaltyType == 'CDN' %}
+          {{ components.button(text='Pay court deposits', type='submit') }}
+        {% elif penaltyType == 'IM' %}
+          {{ components.button(text='Pay immobilisation fee', type='submit') }}
+        {% endif %}
       {%- endcall %}
-    {%- endcall %}
-
-    {% call components.columnOneThird() %}
-    <aside class="govuk-related-items" role="complementary">
-        <nav role="navigation" aria-labelledby="subsection-title">
-          <ul class="font-xsmall">
-            <li> {{ components.link(text='French', url='?clang=fr') if clang != 'fr' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='German', url='?clang=de') if clang != 'de' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Polish', url='?clang=pl') if clang != 'pl' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Spanish', url='?clang=es') if clang != 'es' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Welsh', url='?clang=cy') if clang != 'cy' else components.link(text='English', url='?clang=en') }}</li>
-          </ul>
-        </nav>
-      </aside>
     {%- endcall %}
 
   {%- endcall %}

--- a/src/server/views/payment/penaltyGroupTypeBreakdown.njk
+++ b/src/server/views/payment/penaltyGroupTypeBreakdown.njk
@@ -1,23 +1,28 @@
 {% extends 'layouts/default.layout.njk' %}
 
+{% if penaltyType == 'FPN' %}
+  {% set title = 'Pay fixed penalties' %}
+  {% set breadcrumbLeaf = 'Fixed penalties' %}
+{% elif penaltyType == 'CDN' %}
+  {% set title = 'Pay court deposits' %}
+  {% set breadcrumbLeaf = 'Court deposit' %}
+{% elif penaltyType == 'IM' %}
+  {% set title = 'Pay immobilisation fee' %}
+  {% set breadcrumbLeaf = 'Immobilisation' %}
+{% endif %}
+
 {% set pageTitle = 'DVSA Road Side Payment Portal' %}
 {% set pageBreadcrumbItems = [
     { text: 'Home', url: '/' },
     { text: paymentCode, url: '/payment-code/' + paymentCode },
-    { text: 'Fines' }
+    { text: breadcrumbLeaf }
   ] 
 %}
   
 {% block content %}
   {% call components.gridRow() %}
     {% call components.columnTwoThirds() %}
-        {% if penaltyType == 'FPN' %}
-          {{ components.heading(text='Pay fixed penalties', tag='h1', size='xlarge') }}
-        {% elif penaltyType == 'CDN' %}
-          {{ components.heading(text='Pay court deposits', tag='h1', size='xlarge') }}
-        {% elif penaltyType == 'IM' %}
-          {{ components.heading(text='Pay immobilisation fee', tag='h1', size='xlarge') }}
-        {% endif %}
+      {{ components.heading(text=title, tag='h1', size='xlarge') }}
       {# Payment summary table #}
       <table>
         <thead>

--- a/src/server/views/payment/penaltyGroupTypeBreakdown.njk
+++ b/src/server/views/payment/penaltyGroupTypeBreakdown.njk
@@ -3,12 +3,15 @@
 {% if penaltyType == 'FPN' %}
   {% set title = 'Pay fixed penalties' %}
   {% set breadcrumbLeaf = 'Fixed penalties' %}
+  {% set submitButtonText = 'Pay fixed penalties' %}
 {% elif penaltyType == 'CDN' %}
   {% set title = 'Pay court deposits' %}
   {% set breadcrumbLeaf = 'Court deposit' %}
+  {% set submitButtonText = 'Pay court deposits' %}
 {% elif penaltyType == 'IM' %}
   {% set title = 'Pay immobilisation fee' %}
   {% set breadcrumbLeaf = 'Immobilisation' %}
+  {% set submitButtonText = 'Pay immobilisation fee' %}
 {% endif %}
 
 {% set pageTitle = 'DVSA Road Side Payment Portal' %}
@@ -59,13 +62,7 @@
           {{ components.radio(text='Cheque', value='cheque', id='pay-by-cheque', name='paymentType') }}
           {{ components.radio(text='Postal Order', value='postal', id='pay-by-postal', name='paymentType') }}
         {%- endcall %}
-        {% if penaltyType == 'FPN' %}
-          {{ components.button(text='Pay fixed penalties', type='submit') }}
-        {% elif penaltyType == 'CDN' %}
-          {{ components.button(text='Pay court deposits', type='submit') }}
-        {% elif penaltyType == 'IM' %}
-          {{ components.button(text='Pay immobilisation fee', type='submit') }}
-        {% endif %}
+        {{ components.button(text=submitButtonText, type='submit') }}
       {%- endcall %}
     {%- endcall %}
 

--- a/src/server/views/penalty/penaltyGroupSummary.njk
+++ b/src/server/views/penalty/penaltyGroupSummary.njk
@@ -2,9 +2,8 @@
 
 {% set pageTitle = t.site_title %}
 {% set pageBreadcrumbItems = [
-    { text: t.breadcrumbs.home, url: '/' },
-    { text: t.breadcrumbs.payment_code, url: '/payment-code' },
-    { text: t.breadcrumbs.penalty_details }
+    { text: 'Home', url: '/' },
+    { text: paymentCode }
   ] 
 %}
 
@@ -15,8 +14,7 @@
   {% call components.gridRow() %}
     {% call components.columnTwoThirds() %}
       {% if paid == false %}
-        {{ components.heading(text='Pay a DVSA Penalty', tag='h1', size='xlarge') }}
-        <p>Payment code: <strong>{{ paymentCode }}</strong></p>
+        {{ components.heading(text='Summary of DVSA roadside fines', tag='h1', size='large') }}
         {{ components.paragraph(text='We found the following details in our records') }}
       {% else %}
         {{ components.heading(text='Penalty Payment Confirmation', tag='h1', size='xlarge') }}
@@ -26,6 +24,10 @@
 
       <table class="details">
         <tbody>
+          <tr>
+            <td>Payment code</td>
+            <td>{{ paymentCode }}</td>
+          </tr>
           <tr>
             <td>Vehicle Registration</td>
             {% if isPenaltyGroup == false %}

--- a/src/server/views/penalty/penaltyGroupSummary.njk
+++ b/src/server/views/penalty/penaltyGroupSummary.njk
@@ -74,8 +74,8 @@
                   {% endif %}
                 </span>
               </td>
-              {% if amountPaid == false %}
                 <td class='penalty-type-payment-cell'>
+                  {% if amountPaid == false %}
                     {% if amount.type == 'FPN' %}
                       {% set paymentButtonTxt = 'Pay fixed penalties' %}
                     {% elif amount.type == 'CDN' %}
@@ -86,8 +86,8 @@
                     <div>
                       {{ components.button(text=paymentButtonTxt, url='/payment-code/' + paymentCode + '/' + amount.type + '/details') }}
                     </div>
+                  {% endif %}
                 </td>
-              {% endif %}
             </tr>
           {% endfor %}
         </tbody>

--- a/src/server/views/penalty/penaltyGroupSummary.njk
+++ b/src/server/views/penalty/penaltyGroupSummary.njk
@@ -61,6 +61,12 @@
                   Court Deposits
                 {% elif amount.type == 'IM' %}
                   Immobilisation Fee
+                  <br />
+                  {% for penaltyType in penaltyDetails %}
+                    {% if penaltyType.type == 'IM' %}
+                      {{ penaltyType.penalties[0].formattedReference }}
+                    {% endif %}
+                  {% endfor %}
                 {% endif %}
               </td>
               <td>
@@ -92,6 +98,59 @@
           {% endfor %}
         </tbody>
       </table>
+
+      {% for penaltyType in penaltyDetails %}
+        {% if penaltyType.type == 'FPN' %}
+          <p>
+            <details>
+              <summary><span class="summary">See fixed penalty details</span></summary>
+              <div class="panel panel-border-narrow">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Reference</th>
+                      <th>Amount</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {% for penalty in penaltyType.penalties %}
+                      <tr>
+                        <td>{{ penalty.formattedReference }}</td>
+                        <td>&pound;{{ penalty.amount }}</td>
+                      </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+              </div>
+            </details>    
+          </p>
+        {% elif penaltyType.type == 'CDN' %}
+          <p>
+            <details>
+              <summary><span class="summary">See court deposit details</span></summary>
+              <div class="panel panel-border-narrow">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Reference</th>
+                      <th>Amount</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {% for penalty in penaltyType.penalties %}
+                      <tr>
+                        <td>{{ penalty.formattedReference }}</td>
+                        <td>&pound;{{ penalty.amount }}</td>
+                      </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+              </div>
+            </details>    
+          </p>
+        {% endif %}
+      {% endfor %}
+
       {% if paid %}
         <p>
         You can: &nbsp; 
@@ -104,21 +163,6 @@
         {{ components.button(text='Pay another penalty', url='/payment-code') }}
       {% endif %}
     {# ends components.columnTwoThirds #}
-    {%- endcall %}
-
-    {% call components.columnOneThird() %}
-
-    <aside class="govuk-related-items" role="complementary">
-        <nav role="navigation" aria-labelledby="subsection-title">
-          <ul class="font-xsmall">
-            <li> {{ components.link(text='French', url='?clang=fr') if clang != 'fr' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='German', url='?clang=de') if clang != 'de' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Polish', url='?clang=pl') if clang != 'pl' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Spanish', url='?clang=es') if clang != 'es' else components.link(text='English', url='?clang=en') }}</li>
-            <li>{{ components.link(text='Welsh', url='?clang=cy') if clang != 'cy' else components.link(text='English', url='?clang=en') }}</li>
-          </ul>
-        </nav>
-      </aside>
     {%- endcall %}
   {# ends components.gridRow #}
   {%- endcall %}

--- a/test/controllers/payment.controller.spec.js
+++ b/test/controllers/payment.controller.spec.js
@@ -199,6 +199,23 @@ describe('PaymentController', () => {
         });
     };
 
+    const assertPaymentRecordCreatedForPaymentMethod = (paymentMethod) => {
+      sinon.assert.calledWith(paymentServiceStub, {
+        PaymentCode: '5624r2wupfs',
+        PenaltyType: 'FPN',
+        PaymentDetail: {
+          PaymentMethod: paymentMethod,
+          PaymentRef: 'receipt-ref',
+          PaymentAmount: 120,
+          PaymentDate: sinon.match.number,
+        },
+        PenaltyIds: [
+          '564548184556_FPN',
+          '5281756140484_FPN',
+        ],
+      });
+    };
+
     context('when a cash payment is sent', async () => {
       beforeEach(() => {
         cpmsSvcMock = sinon.stub(CpmsService.prototype, 'createGroupCashTransaction');
@@ -214,33 +231,14 @@ describe('PaymentController', () => {
       });
       it('should create a group cash transaction, make a group payment and return to the receipt page', async () => {
         await PaymentController.makeGroupPayment(request, response);
-        sinon.assert.calledWith(paymentServiceStub, {
-          PaymentCode: '5624r2wupfs',
-          PenaltyType: 'FPN',
-          PaymentDetail: {
-            PaymentMethod: 'CASH',
-            PaymentRef: 'receipt-ref',
-            PaymentAmount: 120,
-            PaymentDate: sinon.match.number,
-          },
-          PenaltyIds: [
-            '564548184556_FPN',
-            '5281756140484_FPN',
-          ],
-        });
+        assertPaymentRecordCreatedForPaymentMethod('CASH');
         sinon.assert.calledWith(redirectSpy, '/payment-code/5624r2wupfs/FPN/receipt');
       });
 
       context('given CPMS orchestration does not indicate the cash payment was successful', () => {
         beforeEach(() => {
           cpmsSvcMock.resetBehavior();
-          cpmsSvcMock.resolves({
-            data: {
-              receipt_reference: 'receipt-ref',
-              code: '001',
-              message: 'Not success',
-            },
-          });
+          cpmsSvcMock.resolves({ data: { receipt_reference: 'receipt-ref', code: '001', message: 'Not success' } });
         });
 
         it('should render the failed payment page', async () => {
@@ -261,20 +259,7 @@ describe('PaymentController', () => {
       });
       it('should create a group cheque transaction, make a group payment and return to the receipt page', async () => {
         await PaymentController.makeGroupPayment(request, response);
-        sinon.assert.calledWith(paymentServiceStub, {
-          PaymentCode: '5624r2wupfs',
-          PenaltyType: 'FPN',
-          PaymentDetail: {
-            PaymentMethod: 'CHEQUE',
-            PaymentRef: 'receipt-ref',
-            PaymentAmount: 120,
-            PaymentDate: sinon.match.number,
-          },
-          PenaltyIds: [
-            '564548184556_FPN',
-            '5281756140484_FPN',
-          ],
-        });
+        assertPaymentRecordCreatedForPaymentMethod('CHEQUE');
         sinon.assert.calledWith(redirectSpy, '/payment-code/5624r2wupfs/FPN/receipt');
       });
     });
@@ -292,20 +277,7 @@ describe('PaymentController', () => {
       });
       it('should create a group postal order transaction, make a group payment and return to the receipt page', async () => {
         await PaymentController.makeGroupPayment(request, response);
-        sinon.assert.calledWith(paymentServiceStub, {
-          PaymentCode: '5624r2wupfs',
-          PenaltyType: 'FPN',
-          PaymentDetail: {
-            PaymentMethod: 'POSTAL_ORDER',
-            PaymentRef: 'receipt-ref',
-            PaymentAmount: 120,
-            PaymentDate: sinon.match.number,
-          },
-          PenaltyIds: [
-            '564548184556_FPN',
-            '5281756140484_FPN',
-          ],
-        });
+        assertPaymentRecordCreatedForPaymentMethod('POSTAL_ORDER');
         sinon.assert.calledWith(redirectSpy, '/payment-code/5624r2wupfs/FPN/receipt');
       });
     });

--- a/test/controllers/payment.controller.spec.js
+++ b/test/controllers/payment.controller.spec.js
@@ -79,6 +79,18 @@ describe('PaymentController', () => {
       });
     });
 
+    context('when the payment type is cheque', () => {
+      const penaltyGroup = fakeEnrichedPenaltyGroups
+        .find(g => g.paymentCode === '5624r2wupfs');
+      beforeEach(() => {
+        request.query.paymentType = 'cheque';
+      });
+      it('should render the cheque group payment page', async () => {
+        await PaymentController.renderGroupPaymentPage(request, response);
+        sinon.assert.calledWith(renderSpy, 'payment/groupCheque', { ...penaltyGroup, paymentPenaltyType: 'FPN' });
+      });
+    });
+
     context('when the payment type is invalid', () => {
       beforeEach(() => {
         request.query.paymentType = 'notvalidtype';

--- a/test/controllers/payment.controller.spec.js
+++ b/test/controllers/payment.controller.spec.js
@@ -216,7 +216,7 @@ describe('PaymentController', () => {
         CpmsService.prototype.createGroupCashTransaction.restore();
         PaymentService.prototype.recordGroupPayment.restore();
       });
-      it('should create a group cash transaction, make a group payment and return to the payment code', async () => {
+      it('should create a group cash transaction, make a group payment and return to the receipt page', async () => {
         await PaymentController.makeGroupPayment(request, response);
         sinon.assert.calledWith(paymentSvcMock, {
           PaymentCode: '5624r2wupfs',

--- a/test/services/cpms.service.spec.js
+++ b/test/services/cpms.service.spec.js
@@ -149,4 +149,52 @@ describe('CPMS Service', () => {
       expect(resolution).to.equal('resolved value');
     });
   });
+
+  describe('createGroupPostalOrderTransaction', () => {
+    const penaltyGroup = fakePenaltyGroups.find(group => group.paymentCode === '5624r2wupfs');
+    beforeEach(() => {
+      httpClientStub = sinon.stub(HttpClient.prototype, 'post');
+      httpClientStub
+        .withArgs('groupPayment/', {
+          TotalAmount: 120,
+          PaymentMethod: 'CASH',
+          VehicleRegistration: '11DDD',
+          PenaltyGroupId: '5624r2wupfs',
+          PenaltyType: 'FPN',
+          SlipNumber: '1234',
+          BatchNumber: 1,
+          PostalOrderNumber: '2468',
+          ReceiptDate: new Date().toISOString().split('T')[0],
+          RedirectUrl: 'https://redirect.url',
+          Penalties: [
+            {
+              PenaltyReference: '564548184556',
+              PenaltyAmount: 100,
+              VehicleRegistration: '11DDD',
+            },
+            {
+              PenaltyReference: '5281756140484',
+              PenaltyAmount: 20,
+              VehicleRegistration: '11DDD',
+            },
+          ],
+        })
+        .resolves('resolved value');
+    });
+    afterEach(() => {
+      HttpClient.prototype.post.restore();
+    });
+    it('should return a POST promise from the groupPayment endpoint', async () => {
+      const resolution = await cpmsService.createGroupPostalOrderTransaction(
+        '5624r2wupfs',
+        penaltyGroup.penaltyGroupDetails,
+        'FPN',
+        penaltyGroup.penaltyDetails,
+        'https://redirect.url',
+        '1234',
+        '2468',
+      );
+      expect(resolution).to.equal('resolved value');
+    });
+  });
 });

--- a/test/services/cpms.service.spec.js
+++ b/test/services/cpms.service.spec.js
@@ -82,14 +82,69 @@ describe('CPMS Service', () => {
         })
         .resolves('resolved value');
     });
+    afterEach(() => {
+      HttpClient.prototype.post.restore();
+    });
     it('should return a POST promise from the groupCashPayment endpoint', async () => {
       const resolution = await cpmsService.createGroupCashTransaction(
         '5624r2wupfs',
         penaltyGroup.penaltyGroupDetails,
         'FPN',
         penaltyGroup.penaltyDetails,
-        '1234',
         'https://redirect.url',
+        '1234',
+      );
+      expect(resolution).to.equal('resolved value');
+    });
+  });
+
+  describe('createGroupChequeTransaction', () => {
+    const penaltyGroup = fakePenaltyGroups.find(group => group.paymentCode === '5624r2wupfs');
+    beforeEach(() => {
+      httpClientStub = sinon.stub(HttpClient.prototype, 'post');
+      httpClientStub
+        .withArgs('groupPayment/', {
+          TotalAmount: 120,
+          PaymentMethod: 'CASH',
+          VehicleRegistration: '11DDD',
+          PenaltyGroupId: '5624r2wupfs',
+          PenaltyType: 'FPN',
+          SlipNumber: '1234',
+          BatchNumber: 1,
+          ReceiptDate: new Date().toISOString().split('T')[0],
+          ChequeNumber: '2468',
+          ChequeDate: sinon.match.date,
+          NameOnCheque: 'Joe Bloggs',
+          RedirectUrl: 'https://redirect.url',
+          Penalties: [
+            {
+              PenaltyReference: '564548184556',
+              PenaltyAmount: 100,
+              VehicleRegistration: '11DDD',
+            },
+            {
+              PenaltyReference: '5281756140484',
+              PenaltyAmount: 20,
+              VehicleRegistration: '11DDD',
+            },
+          ],
+        })
+        .resolves('resolved value');
+    });
+    afterEach(() => {
+      HttpClient.prototype.post.restore();
+    });
+    it('should return a POST promise from the groupPayment endpoint', async () => {
+      const resolution = await cpmsService.createGroupChequeTransaction(
+        '5624r2wupfs',
+        penaltyGroup.penaltyGroupDetails,
+        'FPN',
+        penaltyGroup.penaltyDetails,
+        'https://redirect.url',
+        '1234',
+        '2468',
+        new Date(),
+        'Joe Bloggs',
       );
       expect(resolution).to.equal('resolved value');
     });

--- a/test/services/cpms.service.spec.js
+++ b/test/services/cpms.service.spec.js
@@ -14,7 +14,7 @@ describe('CPMS Service', () => {
     beforeEach(() => {
       httpClientStub = sinon.stub(HttpClient.prototype, 'post');
       httpClientStub
-        .withArgs('groupCardPayment/', {
+        .withArgs('groupPayment/', {
           TotalAmount: 120,
           PaymentMethod: 'CNP',
           VehicleRegistration: '11DDD',
@@ -36,6 +36,10 @@ describe('CPMS Service', () => {
         })
         .resolves('resolved value');
     });
+    afterEach(() => {
+      HttpClient.prototype.post.restore();
+    });
+    
     it('should return POST promise from groupCardNotPresent endpoint', async () => {
       const resolution = await cpmsService.createCardNotPresentGroupTransaction(
         '5624r2wupfs',
@@ -43,6 +47,49 @@ describe('CPMS Service', () => {
         'FPN',
         penaltyGroup.penaltyDetails[0].penalties,
         'http://redirect.url',
+      );
+      expect(resolution).to.equal('resolved value');
+    });
+  });
+
+  describe('createGroupCashTransaction', () => {
+    const penaltyGroup = fakePenaltyGroups.find(group => group.paymentCode === '5624r2wupfs');
+    beforeEach(() => {
+      httpClientStub = sinon.stub(HttpClient.prototype, 'post');
+      httpClientStub
+        .withArgs('groupPayment/', {
+          TotalAmount: 120,
+          PaymentMethod: 'CASH',
+          VehicleRegistration: '11DDD',
+          PenaltyGroupId: '5624r2wupfs',
+          PenaltyType: 'FPN',
+          SlipNumber: '1234',
+          BatchNumber: 1,
+          ReceiptDate: new Date().toISOString().split('T')[0],
+          RedirectUrl: 'https://redirect.url',
+          Penalties: [
+            {
+              PenaltyReference: '564548184556',
+              PenaltyAmount: 100,
+              VehicleRegistration: '11DDD',
+            },
+            {
+              PenaltyReference: '5281756140484',
+              PenaltyAmount: 20,
+              VehicleRegistration: '11DDD',
+            },
+          ],
+        })
+        .resolves('resolved value');
+    });
+    it('should return a POST promise from the groupCashPayment endpoint', async () => {
+      const resolution = await cpmsService.createGroupCashTransaction(
+        '5624r2wupfs',
+        penaltyGroup.penaltyGroupDetails,
+        'FPN',
+        penaltyGroup.penaltyDetails,
+        '1234',
+        'https://redirect.url',
       );
       expect(resolution).to.equal('resolved value');
     });


### PR DESCRIPTION
* Add Nunjucks templates for cash/cheque/postal payments based on single penalty payment forms
* Create payload specific for the payment type and submit to CPMS orchestration on unified `groupPayment` endpoint
* Call payment service to produce a group payment record with the specific payment type