### PR TITLE
Fix for non-card payment + reject search by reference for grouped penalty

### DIFF
--- a/src/public/scss/styles.scss
+++ b/src/public/scss/styles.scss
@@ -55,10 +55,6 @@ table#receipt-breakdown {
   margin-top: 30px;
 }
 
-div#send-receipt-button-container {
-  margin: 25px 0px;
-}
-
 td.penalty-type-payment-cell {
   padding: 20px 0px;
   text-align: right;

--- a/src/server/controllers/main.controller.js
+++ b/src/server/controllers/main.controller.js
@@ -24,7 +24,7 @@ export const index = (req, res) => {
     invalidIM,
     invalid: invalidPaymentCode || invalidCDN || invalidFPN
       || invalidIM,
-    input: invalidPaymentCode ? 'payment code' : 'penalty reference',
+    input: invalidPaymentCode ? 'payment code' : 'fine reference',
   };
 
   res.render('main/index', viewData);

--- a/src/server/controllers/payment.controller.js
+++ b/src/server/controllers/payment.controller.js
@@ -195,11 +195,11 @@ const bindArgsForPaymentType = (partialFn, paymentType, body) => {
     case 'cheque':
       const {
         slipNumber,
-        chequeDate,
         chequeNumber,
+        chequeDate,
         nameOnCheque,
       } = body;
-      return partialFn.bind(cpmsService, slipNumber, chequeDate, chequeNumber, nameOnCheque);
+      return partialFn.bind(cpmsService, slipNumber, chequeNumber, chequeDate, nameOnCheque);
     case 'postal':
       return partialFn.bind(cpmsService, body.slipNumber, body.postalOrderNumber);
     default:

--- a/src/server/services/cpms.service.js
+++ b/src/server/services/cpms.service.js
@@ -58,7 +58,7 @@ export default class PaymentService {
       RedirectUrl: redirectUrl,
       SlipNumber: slipNumber,
       ReceiptDate: new Date().toISOString().split('T')[0],
-      BatchNumber: 1,
+      BatchNumber: '1',
       Penalties: penaltiesOfType.map(p => ({
         PenaltyReference: p.reference,
         PenaltyAmount: p.amount,
@@ -101,14 +101,14 @@ export default class PaymentService {
     const penaltiesOfType = penalties.find(p => p.type === type).penalties;
     const payload = {
       TotalAmount: total,
-      PaymentMethod: 'CASH',
+      PaymentMethod: 'CHEQUE',
       VehicleRegistration: penGrpDetails.registrationNumber,
       PenaltyGroupId: penGrpId,
       PenaltyType: type,
       RedirectUrl: redirectUrl,
       ReceiptDate: new Date().toISOString().split('T')[0],
       SlipNumber: slipNumber,
-      BatchNumber: 1,
+      BatchNumber: '1',
       ChequeNumber: chequeNumber,
       ChequeDate: chequeDate,
       NameOnCheque: nameOnCheque,
@@ -150,7 +150,7 @@ export default class PaymentService {
     const penaltiesOfType = penalties.find(p => p.type === type).penalties;
     const payload = {
       TotalAmount: total,
-      PaymentMethod: 'CASH',
+      PaymentMethod: 'POSTAL_ORDER',
       VehicleRegistration: penGrpDetails.registrationNumber,
       PenaltyGroupId: penGrpId,
       PenaltyType: type,
@@ -158,7 +158,7 @@ export default class PaymentService {
       ReceiptDate: new Date().toISOString().split('T')[0],
       SlipNumber: slipNumber,
       PostalOrderNumber: postalOrderNumber,
-      BatchNumber: 1,
+      BatchNumber: '1',
       Penalties: penaltiesOfType.map(p => ({
         PenaltyReference: p.reference,
         PenaltyAmount: p.amount,

--- a/src/server/services/penalty.service.js
+++ b/src/server/services/penalty.service.js
@@ -61,9 +61,12 @@ export default class PenaltyService {
 
   getById(penaltyId) {
     const promise = new Promise((resolve, reject) => {
-      this.httpClient.get(`${penaltyId}`).then((response) => {
+      this.httpClient.get(`documents/${penaltyId}`).then((response) => {
         if (isEmpty(response.data) || response.data.Enabled === false) {
           reject(new Error('Penalty reference not found'));
+        }
+        if (response.data.Value.inPenaltyGroup) {
+          reject(new Error('Penalty is part of a penalty group'));
         }
         resolve(PenaltyService.parsePenalty(response.data));
       }).catch((error) => {

--- a/src/server/services/penaltyGroup.service.js
+++ b/src/server/services/penaltyGroup.service.js
@@ -87,7 +87,7 @@ export default class PenaltyGroupService {
         penaltyDetails: parsedPenalties,
         penaltyType: type,
         totalAmount: pensOfType.reduce((total, pen) => total + pen.Value.penaltyAmount, 0),
-        paymentStatus: parsedPenalties.every(p => p.status === 'PAID') ? 'PAID' : 'PAID',
+        paymentStatus: parsedPenalties.every(p => p.status === 'PAID') ? 'PAID' : 'UNPAID',
       };
     }).catch((error) => {
       throw new Error(error);

--- a/src/server/services/penaltyGroup.service.js
+++ b/src/server/services/penaltyGroup.service.js
@@ -82,10 +82,12 @@ export default class PenaltyGroupService {
       }
       const { Payments } = response.data;
       const pensOfType = Payments.filter(p => p.PaymentCategory === type)[0].Penalties;
+      const parsedPenalties = pensOfType.map(p => PenaltyService.parsePenalty(p));
       return {
-        penaltyDetails: pensOfType.map(p => PenaltyService.parsePenalty(p)),
+        penaltyDetails: parsedPenalties,
         penaltyType: type,
         totalAmount: pensOfType.reduce((total, pen) => total + pen.Value.penaltyAmount, 0),
+        paymentStatus: parsedPenalties.every(p => p.status === 'PAID') ? 'PAID' : 'PAID',
       };
     }).catch((error) => {
       throw new Error(error);

--- a/src/server/views/layouts/partials/body-scripts.njk
+++ b/src/server/views/layouts/partials/body-scripts.njk
@@ -2,4 +2,10 @@
 <script type="text/javascript" src="{{ assets }}/javascripts/dvsa.bundle.js"></script>
 
 {% block bodyScripts %}{% endblock %}
+
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PK7Z5N2"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+
 <!-- /body-scripts -->

--- a/src/server/views/layouts/partials/head.njk
+++ b/src/server/views/layouts/partials/head.njk
@@ -27,12 +27,10 @@
 <script>
   $.noConflict();
 </script>
-<script type="text/javascript">
-// (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-// (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-// m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-// })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-// ga('create', 'UA-49672752-1', 'govuk-elements.herokuapp.com');
-// ga('send', 'pageview');
-</script>
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-PK7Z5N2');</script>
+<!-- End Google Tag Manager -->

--- a/src/server/views/layouts/partials/header.njk
+++ b/src/server/views/layouts/partials/header.njk
@@ -8,7 +8,7 @@
         </a>
       </div>
     </div>
-  <a href="/{{ urlroot }}/logout" title="Logout">
+  <a href="{{ urlroot }}/logout" title="Logout">
     {{ components.heading(text='Logout', tag='h3', size='small', extraClass='userInfo') }}
   </a>
   {{ components.heading(text='Logged in as '+settings.rsp_user.name, tag='h3', size='small', extraClass='userInfo') }}

--- a/src/server/views/layouts/partials/header.njk
+++ b/src/server/views/layouts/partials/header.njk
@@ -8,7 +8,7 @@
         </a>
       </div>
     </div>
-  <a href="/logout" title="Logout">
+  <a href="/{{ urlroot }}/logout" title="Logout">
     {{ components.heading(text='Logout', tag='h3', size='small', extraClass='userInfo') }}
   </a>
   {{ components.heading(text='Logged in as '+settings.rsp_user.name, tag='h3', size='small', extraClass='userInfo') }}

--- a/src/server/views/main/index.njk
+++ b/src/server/views/main/index.njk
@@ -11,7 +11,7 @@
 
     {% call components.columnTwoThirds() %}
 
-      {{ components.heading(text='Take payments for DVSA penalties', tag='h1', size='xlarge') }}
+      {{ components.heading(text='Take payments for DVSA roadside fines', tag='h1', size='xlarge') }}
 
       {% if invalid %}
         <div class="error-summary" role="alert" aria-labelledby="error-summary-payment-code" tabindex="-1">

--- a/src/server/views/payment/multiPaymentReceipt.njk
+++ b/src/server/views/payment/multiPaymentReceipt.njk
@@ -138,13 +138,7 @@
           {% endfor %}
         </thead>
       </table>
-
-      <h3 class="heading-medium">Send payment receipt by email</h3>
-      {{ components.field(id='email_address', label='Email address') }}
-      <div id="send-receipt-button-container">
-        {{ components.button(text='Send receipt', type="submit") }}
-      </div>
-
+      <br />
       <p>
         <a href='{{ urlroot }}/payment-code/{{ paymentCode }}'>Return to the payment code summary</a>
       </p>

--- a/src/server/views/payment/penaltyGroupTypeBreakdown.njk
+++ b/src/server/views/payment/penaltyGroupTypeBreakdown.njk
@@ -54,16 +54,19 @@
         </tbody>
       </table>
       <br />
-      {% call components.form(action='/payment-code/' + paymentCode + '/' + penaltyType + '/payment', method='GET')  %}
-        {% call components.formGroup() %}
-          {{ components.heading(text='Payment by', tag='h3', size='medium') }}
-          {{ components.radio(text='Card (external website)', value='card', id='pay-by-card', name='paymentType', checked="true") }}
-          {{ components.radio(text='Cash', value='cash', id='pay-by-cash', name='paymentType') }}
-          {{ components.radio(text='Cheque', value='cheque', id='pay-by-cheque', name='paymentType') }}
-          {{ components.radio(text='Postal Order', value='postal', id='pay-by-postal', name='paymentType') }}
+      {% if paymentStatus !== 'PAID' %}
+        {% call components.form(action='/payment-code/' + paymentCode + '/' + penaltyType + '/payment', method='GET')  %}
+          {% call components.formGroup() %}
+            {{ components.heading(text='Payment by', tag='h3', size='medium') }}
+            {{ components.radio(text='Card (external website)', value='card', id='pay-by-card', name='paymentType', checked="true") }}
+            {{ components.radio(text='Cash', value='cash', id='pay-by-cash', name='paymentType') }}
+            {{ components.radio(text='Cheque', value='cheque', id='pay-by-cheque', name='paymentType') }}
+            {{ components.radio(text='Postal Order', value='postal', id='pay-by-postal', name='paymentType') }}
+          {%- endcall %}
+          {{ components.button(text=submitButtonText, type='submit') }}
         {%- endcall %}
-        {{ components.button(text=submitButtonText, type='submit') }}
-      {%- endcall %}
+      {% endif %}
+
     {%- endcall %}
 
   {%- endcall %}

--- a/src/server/views/penalty/penaltyGroupSummary.njk
+++ b/src/server/views/penalty/penaltyGroupSummary.njk
@@ -17,9 +17,9 @@
         {{ components.heading(text='Summary of DVSA roadside fines', tag='h1', size='large') }}
         {{ components.paragraph(text='We found the following details in our records') }}
       {% else %}
-        {{ components.heading(text='Penalty Payment Confirmation', tag='h1', size='xlarge') }}
-        <p>You paid a penalty for the payment code:&nbsp;<b>{{ paymentCode }}</b>
-        {{ components.paragraph(text='A confirmation has been sent to the DVSA location where the penalty has been issued.') }}
+        {{ components.heading(text='Payment confirmation', tag='h1', size='xlarge') }}
+        <p>All outstanding fines for this payment code have been paid.</p>
+        {{ components.paragraph(text='A confirmation has been sent to the DVSA location where it was issued.') }}
       {% endif %}
 
       <table class="details">
@@ -154,15 +154,7 @@
       {% endfor %}
 
       {% if paid %}
-        <p>
-        You can: &nbsp; 
-          {{ components.list(items=[
-            { text: 'share payment confirmation via SMS', url: '#' },
-            { text: 'share payment confirmation via email', url: '#' },
-            { text: 'alternatively, make a note of the confirmation code for later reference.' }
-          ], type='bullet') }}
-        </p>
-        {{ components.button(text='Pay another penalty', url='/payment-code') }}
+        {{ components.button(text='Home', url='/') }}
       {% endif %}
     {# ends components.columnTwoThirds #}
     {%- endcall %}

--- a/test/controllers/payment.controller.spec.js
+++ b/test/controllers/payment.controller.spec.js
@@ -181,7 +181,7 @@ describe('PaymentController', () => {
 
   describe('makeGroupPayment', () => {
     let cpmsSvcMock;
-    const standardTransactionPayloadWithExtraArgsResolvesSuccess = (a, ...rest) => { // eslint-disable-line
+    const standardTransactionPayloadWithExtraArgsResolvesSuccess = (...rest) => { // eslint-disable-line
       return cpmsSvcMock.withArgs(
         '5624r2wupfs',
         penaltyGroup.penaltyGroupDetails,
@@ -219,7 +219,7 @@ describe('PaymentController', () => {
     context('when a cash payment is sent', async () => {
       beforeEach(() => {
         cpmsSvcMock = sinon.stub(CpmsService.prototype, 'createGroupCashTransaction');
-        standardTransactionPayloadWithExtraArgsResolvesSuccess(cpmsSvcMock, '1234');
+        standardTransactionPayloadWithExtraArgsResolvesSuccess('1234');
         request = {
           body: { paymentType: 'cash', slipNumber: '1234' },
           params: { payment_code: '5624r2wupfs', type: 'FPN' },
@@ -251,8 +251,18 @@ describe('PaymentController', () => {
     context('when a cheque payment is sent', () => {
       beforeEach(() => {
         cpmsSvcMock = sinon.stub(CpmsService.prototype, 'createGroupChequeTransaction');
-        standardTransactionPayloadWithExtraArgsResolvesSuccess(cpmsSvcMock, '1234');
-        request.body.paymentType = 'cheque';
+        standardTransactionPayloadWithExtraArgsResolvesSuccess('2468', '369', '2018-08-24', 'Joe Bloggs');
+        request = {
+          body: {
+            paymentType: 'cheque',
+            slipNumber: '2468',
+            chequeNumber: '369',
+            chequeDate: '2018-08-24',
+            nameOnCheque: 'Joe Bloggs',
+          },
+          params: { payment_code: '5624r2wupfs', type: 'FPN' },
+          get: () => 'localhost',
+        };
       });
       afterEach(() => {
         CpmsService.prototype.createGroupChequeTransaction.restore();
@@ -267,7 +277,7 @@ describe('PaymentController', () => {
     context('when a postal payment is sent', () => {
       beforeEach(() => {
         cpmsSvcMock = sinon.stub(CpmsService.prototype, 'createGroupPostalOrderTransaction');
-        standardTransactionPayloadWithExtraArgsResolvesSuccess(cpmsSvcMock, '1234', '2468');
+        standardTransactionPayloadWithExtraArgsResolvesSuccess('1234', '2468');
         request.body.paymentType = 'postal';
         request.body.slipNumber = '1234';
         request.body.postalOrderNumber = '2468';

--- a/test/controllers/payment.controller.spec.js
+++ b/test/controllers/payment.controller.spec.js
@@ -48,6 +48,21 @@ describe('PaymentController', () => {
       });
     });
 
+    context('when one of the collaborators rejects', () => {
+      let cpmsServiceStub;
+      beforeEach(() => {
+        cpmsServiceStub = sinon.stub(CpmsService.prototype, 'createCardNotPresentGroupTransaction');
+        cpmsServiceStub.rejects(new Error('timed out'));
+      });
+      afterEach(() => {
+        CpmsService.prototype.createCardNotPresentGroupTransaction.restore();
+      });
+      it('should redirect back to the payment code', async () => {
+        await PaymentController.renderGroupPaymentPage(request, response);
+        sinon.assert.calledWith(redirectSpy, '/payment-code/5624r2wupfs');
+      });
+    });
+
     context('when the payment type is card', () => {
       let cpmsServiceStub;
       beforeEach(() => {

--- a/test/data/penalties.js
+++ b/test/data/penalties.js
@@ -39,4 +39,19 @@ export default [
     paymentDate: 1519135329,
     paymentAuthCode: '1234TBD',
   },
+  {
+    inPenaltyGroup: true,
+    paymentStatus: 'UNPAID',
+    paymentToken: '3333333333333333',
+    penaltyType: 'FPN',
+    penaltyAmount: 100,
+    referenceNo: '4597595755914',
+    vehicleDetails: {
+      regNo: 'ABC123',
+    },
+    dateTime: 1419171700,
+    placeWhereIssued: 'Ashford HRTI',
+    paymentDate: 1519135329,
+    paymentAuthCode: '1234TBD',
+  },
 ];

--- a/test/services/cpms.service.spec.js
+++ b/test/services/cpms.service.spec.js
@@ -64,7 +64,7 @@ describe('CPMS Service', () => {
           PenaltyGroupId: '5624r2wupfs',
           PenaltyType: 'FPN',
           SlipNumber: '1234',
-          BatchNumber: 1,
+          BatchNumber: '1',
           ReceiptDate: new Date().toISOString().split('T')[0],
           RedirectUrl: 'https://redirect.url',
           Penalties: [
@@ -105,12 +105,12 @@ describe('CPMS Service', () => {
       httpClientStub
         .withArgs('groupPayment/', {
           TotalAmount: 120,
-          PaymentMethod: 'CASH',
+          PaymentMethod: 'CHEQUE',
           VehicleRegistration: '11DDD',
           PenaltyGroupId: '5624r2wupfs',
           PenaltyType: 'FPN',
           SlipNumber: '1234',
-          BatchNumber: 1,
+          BatchNumber: '1',
           ReceiptDate: new Date().toISOString().split('T')[0],
           ChequeNumber: '2468',
           ChequeDate: sinon.match.date,
@@ -157,12 +157,12 @@ describe('CPMS Service', () => {
       httpClientStub
         .withArgs('groupPayment/', {
           TotalAmount: 120,
-          PaymentMethod: 'CASH',
+          PaymentMethod: 'POSTAL_ORDER',
           VehicleRegistration: '11DDD',
           PenaltyGroupId: '5624r2wupfs',
           PenaltyType: 'FPN',
           SlipNumber: '1234',
-          BatchNumber: 1,
+          BatchNumber: '1',
           PostalOrderNumber: '2468',
           ReceiptDate: new Date().toISOString().split('T')[0],
           RedirectUrl: 'https://redirect.url',

--- a/test/services/penalty.service.spec.js
+++ b/test/services/penalty.service.spec.js
@@ -82,5 +82,16 @@ describe('Penalty Service', () => {
       // Assert
       return expect(result).to.be.rejected;
     });
+    it('should return a rejected promise [WHEN] a reference refers to a penalty which is part of a group', () => {
+      const groupReferenceNumber = '4597595755914';
+
+      mockedHttpClient = sinon.stub(httpClient, 'get').callsFake(reference => mockedBackendAPI.getPenaltyByReference(reference));
+      penaltyService = new PenaltyService();
+      penaltyService.httpClient = mockedHttpClient.rootObj;
+
+      const result = penaltyService.getById(groupReferenceNumber);
+
+      return expect(result).to.be.rejected;
+    });
   });
 });


### PR DESCRIPTION
* Ensure `BatchNumber` sent to CPMS orchestration is a string, not a number
* Replace `CASH` `PaymentMethod` with for postal/cheque
* Fix `chequeNumber` and `chequeDate` being inverted in CPMS transaction call
* Update copy for user testing