### PR TITLE
Fix CPMS transaction creation failure in production

### DIFF
--- a/src/server/config.js
+++ b/src/server/config.js
@@ -33,6 +33,7 @@ const cognitoUrl = process.env.COGNITO_URL;
 const cpmsServiceUrl = process.env.CPMS_SERVICE_URL;
 const iamClientId = process.env.IAM_CLIENT_ID;
 const iamClientSecret = process.env.IAM_CLIENT_SECRET;
+const postPaymentRedirectBaseUrl = process.env.POST_PAYMENT_REDIRECT_BASE_URL;
 
 const config = {
   env,
@@ -53,6 +54,7 @@ const config = {
   cpmsServiceUrl,
   iamClientId,
   iamClientSecret,
+  postPaymentRedirectBaseUrl,
 };
 
 export default config;

--- a/src/server/controllers/payment.controller.js
+++ b/src/server/controllers/payment.controller.js
@@ -142,7 +142,7 @@ export const makeGroupPayment = async (req, res) => {
     const penaltiesOfType = penaltyGroup.penaltyDetails.find(p => p.type === penaltyType).penalties;
     const amountPaidForType = penaltyGroup.penaltyGroupDetails.splitAmounts
       .find(s => s.type === penaltyType).amount;
-    const redirectUrl = `https://${req.get('host')}${config.urlRoot}/payment-code/${paymentCode}/${penaltyType}/receipt`;
+    const redirectUrl = `${config.postPaymentRedirectBaseUrl}/payment-code/${paymentCode}/${penaltyType}/receipt`;
 
     const paymentMethodMappings = {
       cash: { transactionCreationFunction: cpmsService.createGroupCashTransaction, paymentRecordMethod: 'CASH' },
@@ -223,7 +223,7 @@ export const renderPaymentPage = async (req, res) => {
     // Payment Type is expected to come from the query string, otherwise the default is used
     const paymentType = req.query.paymentType ? req.query.paymentType : 'card';
     const { paymentCode } = penaltyDetails;
-    const redirectUrl = `https://${req.get('host')}${config.urlRoot}/payment-code/${paymentCode}/confirmPayment`;
+    const redirectUrl = `${config.postPaymentRedirectBaseUrl}/payment-code/${paymentCode}/confirmPayment`;
 
     switch (paymentType) {
       case 'cash':
@@ -265,8 +265,7 @@ export const renderGroupPaymentPage = async (req, res) => {
     if (paymentType === 'card') {
       const penaltyDetails = penaltyGroup.penaltyDetails
         .find(typeGrp => typeGrp.type === penaltyType).penalties;
-      const redirectUrl = `https://${req.get('host')}${config.urlRoot}/payment-code/${paymentCode}/${penaltyType}/confirmGroupPayment`;
-
+      const redirectUrl = `${config.postPaymentRedirectBaseUrl}/payment-code/${paymentCode}/${penaltyType}/confirmGroupPayment`;
       const cpmsResp = await cpmsService.createCardNotPresentGroupTransaction(
         penaltyGroup.paymentCode,
         penaltyGroup.penaltyGroupDetails,

--- a/test/controllers/payment.controller.spec.js
+++ b/test/controllers/payment.controller.spec.js
@@ -34,7 +34,6 @@ describe('PaymentController', () => {
       request = {
         params: { payment_code: '5624r2wupfs', type: 'FPN' },
         query: { paymentType: 'card' },
-        get: () => 'localhost',
       };
     });
 
@@ -73,7 +72,7 @@ describe('PaymentController', () => {
             penaltyGroup.penaltyGroupDetails,
             'FPN',
             penaltyGroup.penaltyDetails[0].penalties,
-            'https://localhost/payment-code/5624r2wupfs/FPN/confirmGroupPayment',
+            'http://localhost:3000/payment-code/5624r2wupfs/FPN/confirmGroupPayment',
           )
           .resolves({ data: { gateway_url: 'https://cpms.url' } });
       });
@@ -202,7 +201,7 @@ describe('PaymentController', () => {
         penaltyGroup.penaltyGroupDetails,
         'FPN',
         penaltyGroup.penaltyDetails,
-        'https://localhost/payment-code/5624r2wupfs/FPN/receipt',
+        'http://localhost:3000/payment-code/5624r2wupfs/FPN/receipt',
         ...rest,
       )
         .resolves({
@@ -238,7 +237,6 @@ describe('PaymentController', () => {
         request = {
           body: { paymentType: 'cash', slipNumber: '1234' },
           params: { payment_code: '5624r2wupfs', type: 'FPN' },
-          get: () => 'localhost',
         };
       });
       afterEach(() => {
@@ -276,7 +274,6 @@ describe('PaymentController', () => {
             nameOnCheque: 'Joe Bloggs',
           },
           params: { payment_code: '5624r2wupfs', type: 'FPN' },
-          get: () => 'localhost',
         };
       });
       afterEach(() => {


### PR DESCRIPTION
* Usage of host header to generate redirect URL creates an internal URL
  to the public portal containing an API prefix
* CPMS only whitelist the public URL, so they reject the transaction
* Add new envvar POST_PAYMENT_REDIRECT_BASE_URL to configure the base of
  the public portal URL to return to