### PR TITLE
Fix report generation status checking failure

### DIFF
--- a/src/server/views/reports/generatingReport.njk
+++ b/src/server/views/reports/generatingReport.njk
@@ -47,7 +47,7 @@ jQuery(document).ready(function($) {
     $.get(baseUrl + 'reports/'+reportReference+'/status?penalty_type='+penaltyType, function(response) {
       if(response.completed) {
         complete = true;
-        window.location = baseUrl+'/reports/'+reportReference+'?penalty_type='+penaltyType;
+        window.location = baseUrl+'reports/'+reportReference+'?penalty_type='+penaltyType;
       }
     });
     if(!complete) {


### PR DESCRIPTION
* Report generation polling page was never reaching the download report
  page in prod
* Base 64 content was returned due to missing binary media types
  setting on API gateway
* Base 64 caused report status AJAX to fail due to incompatibility
  with application/json Content-Type header
* Extra slash on status check success redirect URL caused 404
* Remove extra slash after baseUrl, as the baseUrl has a trailing slash
  on dev/prod to reach the download page