### PR TITLE
Fix issue where user info cookie was not being set in dev/prod envs

### DIFF
--- a/src/server/app.js
+++ b/src/server/app.js
@@ -51,7 +51,6 @@ env.express(app);
 
 app.use(session({
   maxAge: 1000 * 60 * 60 * 4, // 4 hours
-  secure: true,
   name: 'rsp_internal_portal_user',
   // TODO: clientSecret will be removed eventually, will need to use a different app secret for this
   secret: config.clientSecret,


### PR DESCRIPTION
* On dev/prod environments, TLS is terminated by API Gateway and proxied
  to express which is serving standard HTTP
* Session cookie secure configuration prevented cookie being set,
  meaning pages other than the start page had undefined user info
* Remove secure configuration to ensure cookie is set