### PR TITLE
Prevent hiding of link on search results for cancelled payment codes

### DIFF
--- a/src/server/views/penalty/vehicleRegSearchResults.njk
+++ b/src/server/views/penalty/vehicleRegSearchResults.njk
@@ -21,13 +21,7 @@
       <tbody>
         {% for result in results|sort(attribute='date', reverse=true) %}
           <tr>
-            <td>
-              {% if result.paymentStatus != 'CANCELLED' %}
-                {{ components.link(text=result.paymentCode, url='/payment-code/' + result.paymentCode) }}
-              {% else %}
-                {{ result.paymentCode }}
-              {% endif %}
-            </td>
+            <td>{{ components.link(text=result.paymentCode, url='/payment-code/' + result.paymentCode) }}</td>
             <td>{{ result.formattedDate }}</td>
               {% set statusClass = 'confirmed' if result.paymentStatus == 'PAID' else 'unconfirmed' %}
               <td><span class='{{statusClass}}'><strong>{{ result.paymentStatus }}</strong></span></td>


### PR DESCRIPTION
* Previously, we didn't allow operators to visit cancelled payment codes
  due to API restrictions
* Now documents doesn't 404 for cancelled penalties we allow cancelled
  penalties to be viewed
* Remove check for whether the code is cancelled when deciding whether
  or not to show the payment code link