### PR TITLE
Fix unhyphenated IM references in CPMS transaction sales_reference

### DIFF
--- a/src/server/controllers/payment.controller.js
+++ b/src/server/controllers/payment.controller.js
@@ -260,7 +260,7 @@ export const renderPaymentPage = async (req, res) => {
         return cpmsService.createCardNotPresentTransaction(
           paymentCode,
           penaltyDetails.vehicleReg,
-          penaltyDetails.reference,
+          penaltyDetails.formattedReference,
           penaltyDetails.type,
           penaltyDetails.amount,
           redirectUrl,

--- a/src/server/controllers/payment.controller.js
+++ b/src/server/controllers/payment.controller.js
@@ -39,7 +39,7 @@ export const makePayment = async (req, res) => {
         return cpmsService.createCashTransaction(
           paymentCode,
           penaltyDetails.vehicleReg,
-          penaltyDetails.reference,
+          penaltyDetails.formattedReference,
           penaltyDetails.type,
           penaltyDetails.amount,
           details.slipNumber,
@@ -47,7 +47,7 @@ export const makePayment = async (req, res) => {
           const paymentDetails = {
             PenaltyStatus: 'PAID',
             PenaltyType: penaltyDetails.type,
-            PenaltyReference: penaltyDetails.reference,
+            PenaltyReference: penaltyDetails.formattedReference,
             PaymentDetail: {
               PaymentMethod: req.body.paymentType.toUpperCase(),
               PaymentRef: response.data.receipt_reference,
@@ -73,12 +73,14 @@ export const makePayment = async (req, res) => {
           }
         } else {
           const matchedRoles = intersection(chequeAuthorizedRoles, userRole);
-          if (!matchedRoles.length) return res.render('main/forbidden', req.session);
+          if (!matchedRoles.length) {
+            return res.render('main/forbidden', req.session);
+          }
         }
         return cpmsService.createChequeTransaction(
           paymentCode,
           penaltyDetails.vehicleReg,
-          penaltyDetails.reference,
+          penaltyDetails.formattedReference,
           penaltyDetails.type,
           penaltyDetails.amount,
           details.slipNumber,
@@ -89,7 +91,7 @@ export const makePayment = async (req, res) => {
           const paymentDetails = {
             PenaltyStatus: 'PAID',
             PenaltyType: penaltyDetails.type,
-            PenaltyReference: penaltyDetails.reference,
+            PenaltyReference: penaltyDetails.formattedReference,
             PaymentDetail: {
               PaymentMethod: req.body.paymentType.toUpperCase(),
               PaymentRef: response.data.receipt_reference,
@@ -111,7 +113,7 @@ export const makePayment = async (req, res) => {
         return cpmsService.createPostalOrderTransaction(
           paymentCode,
           penaltyDetails.vehicleReg,
-          penaltyDetails.reference,
+          penaltyDetails.formattedReference,
           penaltyDetails.type,
           penaltyDetails.amount,
           details.slipNumber,
@@ -120,7 +122,7 @@ export const makePayment = async (req, res) => {
           const paymentDetails = {
             PenaltyStatus: 'PAID',
             PenaltyType: penaltyDetails.type,
-            PenaltyReference: penaltyDetails.reference,
+            PenaltyReference: penaltyDetails.formattedReference,
             PaymentDetail: {
               PaymentMethod: req.body.paymentType.toUpperCase(),
               PaymentRef: response.data.receipt_reference,

--- a/src/server/services/cpms.service.js
+++ b/src/server/services/cpms.service.js
@@ -28,7 +28,7 @@ export default class PaymentService {
       PenaltyType: type,
       RedirectUrl: redirectUrl,
       Penalties: penalties.map(p => ({
-        PenaltyReference: p.reference,
+        PenaltyReference: p.formattedReference,
         PenaltyAmount: p.amount,
         VehicleRegistration: p.vehicleReg,
       })),
@@ -65,7 +65,7 @@ export default class PaymentService {
       ReceiptDate: new Date().toISOString().split('T')[0],
       BatchNumber: slipNumber,
       Penalties: penaltiesOfType.map(p => ({
-        PenaltyReference: p.reference,
+        PenaltyReference: p.formattedReference,
         PenaltyAmount: p.amount,
         VehicleRegistration: p.vehicleReg,
       })),
@@ -120,7 +120,7 @@ export default class PaymentService {
       ChequeDate: chequeDate,
       NameOnCheque: nameOnCheque,
       Penalties: penaltiesOfType.map(p => ({
-        PenaltyReference: p.reference,
+        PenaltyReference: p.formattedReference,
         PenaltyAmount: p.amount,
         VehicleRegistration: p.vehicleReg,
       })),
@@ -169,7 +169,7 @@ export default class PaymentService {
       PostalOrderNumber: postalOrderNumber,
       BatchNumber: slipNumber,
       Penalties: penaltiesOfType.map(p => ({
-        PenaltyReference: p.reference,
+        PenaltyReference: p.formattedReference,
         PenaltyAmount: p.amount,
         VehicleRegistration: p.vehicleReg,
       })),

--- a/test/controllers/payment.controller.spec.js
+++ b/test/controllers/payment.controller.spec.js
@@ -3,10 +3,12 @@ import sinon from 'sinon';
 import * as PaymentController from '../../src/server/controllers/payment.controller';
 import config from '../../src/server/config';
 import CpmsService from '../../src/server/services/cpms.service';
+import PenaltyService from '../../src/server/services/penalty.service';
 import PenaltyGroupService from '../../src/server/services/penaltyGroup.service';
 import getPenaltyGroupFake from '../data/penaltyGroup/enchrichedPenaltyGroupFake';
 import fakeEnrichedPenaltyGroups from '../data/penaltyGroup/fake-penalty-groups-enriched.json';
 import PaymentService from '../../src/server/services/payment.service';
+import penaltyServiceGetResponses from '../data/penaltyServiceGetResponses';
 
 const penaltyGroup = fakeEnrichedPenaltyGroups.find(g => g.paymentCode === '5624r2wupfs');
 
@@ -325,6 +327,110 @@ describe('PaymentController', () => {
         await PaymentController.makeGroupPayment(request, response);
         assertPaymentRecordCreatedForPaymentMethod('POSTAL_ORDER');
         sinon.assert.calledWith(redirectSpy, '/payment-code/5624r2wupfs/FPN/receipt');
+      });
+    });
+  });
+
+  describe('makePayment', () => {
+    const paymentCode = '5260825bbe245e1a';
+    const cpmsReceiptRef = 'FB02-01-20180816-091027-B9AA05B9';
+    const imReference = '945872-0-776-IM';
+    const vehicleReg = '17EEE';
+    const slipNumber = 2468;
+    const requestParams = { payment_code: paymentCode };
+    let penaltySvcStub;
+    let cpmsServiceStub;
+    const expectedPaymentSvcPayloadForPaymentType = type => ({
+      PenaltyStatus: 'PAID',
+      PenaltyType: 'IM',
+      PenaltyReference: imReference,
+      PaymentDetail: {
+        PaymentMethod: type,
+        PaymentRef: cpmsReceiptRef,
+        PaymentAmount: 80,
+        PaymentDate: sinon.match.number,
+      },
+    });
+
+    beforeEach(() => {
+      penaltySvcStub = sinon.stub(PenaltyService.prototype, 'getByPaymentCode');
+      penaltySvcStub
+        .callsFake(c => Promise.resolve(penaltyServiceGetResponses.find(p => p.paymentCode === c)));
+      paymentServiceStub = sinon.stub(PaymentService.prototype, 'makePayment');
+      request = { params: requestParams, session: { rsp_user_role: 'BankingFinance' } };
+    });
+    afterEach(() => {
+      PenaltyService.prototype.getByPaymentCode.restore();
+      PaymentService.prototype.makePayment.restore();
+    });
+
+    context('when a cash payment is made', () => {
+      beforeEach(() => {
+        request.body = { paymentType: 'cash', slipNumber };
+        cpmsServiceStub = sinon.stub(CpmsService.prototype, 'createCashTransaction');
+        cpmsServiceStub
+          .withArgs(paymentCode, vehicleReg, imReference, 'IM', 80, slipNumber)
+          .resolves({ data: { receipt_reference: cpmsReceiptRef } });
+        paymentServiceStub.resolves();
+      });
+      afterEach(() => {
+        CpmsService.prototype.createCashTransaction.restore();
+      });
+      it('create a cash transaction, persist it and return to payment code summary', async () => {
+        await PaymentController.makePayment(request, response);
+        sinon.assert.calledWith(paymentServiceStub, expectedPaymentSvcPayloadForPaymentType('CASH'));
+        sinon.assert.calledWith(redirectSpy, `/payment-code/${paymentCode}`);
+      });
+    });
+
+    context('when a cheque payment is made', () => {
+      const chequeDate = '04/10/2018';
+      const chequeNumber = '9876';
+      const nameOnCheque = 'Joe Bloggs';
+      beforeEach(() => {
+        request.body = {
+          paymentType: 'cheque',
+          slipNumber,
+          chequeDate,
+          chequeNumber,
+          nameOnCheque,
+        };
+        cpmsServiceStub = sinon.stub(CpmsService.prototype, 'createChequeTransaction');
+        cpmsServiceStub
+          .withArgs(
+            paymentCode, vehicleReg, imReference, 'IM', 80, slipNumber,
+            chequeDate, chequeNumber, nameOnCheque,
+          )
+          .resolves({ data: { receipt_reference: cpmsReceiptRef } });
+        paymentServiceStub.resolves();
+      });
+      afterEach(() => {
+        CpmsService.prototype.createChequeTransaction.restore();
+      });
+      it('create a cheque transaction, persist it and return to payment code summary', async () => {
+        await PaymentController.makePayment(request, response);
+        sinon.assert.calledWith(paymentServiceStub, expectedPaymentSvcPayloadForPaymentType('CHEQUE'));
+        sinon.assert.calledWith(redirectSpy, `/payment-code/${paymentCode}`);
+      });
+    });
+
+    context('when a postal payment is made', () => {
+      const postalOrderNumber = 5555;
+      beforeEach(() => {
+        request.body = { paymentType: 'postal', slipNumber, postalOrderNumber };
+        cpmsServiceStub = sinon.stub(CpmsService.prototype, 'createPostalOrderTransaction');
+        cpmsServiceStub
+          .withArgs(paymentCode, vehicleReg, imReference, 'IM', 80, slipNumber, postalOrderNumber)
+          .resolves({ data: { receipt_reference: cpmsReceiptRef } });
+        paymentServiceStub.resolves();
+      });
+      afterEach(() => {
+        CpmsService.prototype.createPostalOrderTransaction.restore();
+      });
+      it('create a postal transaction, persist it and return to payment code summary', async () => {
+        await PaymentController.makePayment(request, response);
+        sinon.assert.calledWith(paymentServiceStub, expectedPaymentSvcPayloadForPaymentType('POSTAL'));
+        sinon.assert.calledWith(redirectSpy, `/payment-code/${paymentCode}`);
       });
     });
   });

--- a/test/data/penaltyServiceGetResponses.js
+++ b/test/data/penaltyServiceGetResponses.js
@@ -1,0 +1,16 @@
+export default [
+  {
+    complete: true,
+    reference: '9458720000776',
+    paymentCode: '5260825bbe245e1a',
+    issueDate: '04/10/2018',
+    vehicleReg: '17EEE',
+    formattedReference: '945872-0-776-IM',
+    location: 'Bury St Edmunds Sector Office(Bury St Edmunds - E. Anglia)',
+    amount: 80,
+    status: 'UNPAID',
+    type: 'IM',
+    typeDescription: 'immobilisation',
+    enabled: true,
+  },
+];

--- a/test/services/cpms.service.spec.js
+++ b/test/services/cpms.service.spec.js
@@ -8,193 +8,337 @@ import HttpClient from '../../src/server/utils/httpclient';
 describe('CPMS Service', () => {
   const cpmsService = new CpmsService('localhost');
   let httpClientStub;
+  beforeEach(() => {
+    httpClientStub = sinon.stub(HttpClient.prototype, 'post');
+  });
+  afterEach(() => {
+    HttpClient.prototype.post.restore();
+  });
+
+  const penaltyGroup = fakePenaltyGroups.find(group => group.paymentCode === '5624r2wupfs');
 
   describe('createCardNotPresentGroupTransaction', () => {
-    const penaltyGroup = fakePenaltyGroups.find(group => group.paymentCode === '5624r2wupfs');
-    beforeEach(() => {
-      httpClientStub = sinon.stub(HttpClient.prototype, 'post');
-      httpClientStub
-        .withArgs('groupPayment/', {
-          TotalAmount: 120,
-          PaymentMethod: 'CNP',
-          VehicleRegistration: '11DDD',
-          PenaltyGroupId: '5624r2wupfs',
-          PenaltyType: 'FPN',
-          RedirectUrl: 'http://redirect.url',
-          Penalties: [
-            {
-              PenaltyReference: '564548184556',
-              PenaltyAmount: 100,
-              VehicleRegistration: '11DDD',
-            },
-            {
-              PenaltyReference: '5281756140484',
-              PenaltyAmount: 20,
-              VehicleRegistration: '11DDD',
-            },
-          ],
-        })
-        .resolves('resolved value');
+    context('for a group of fixed penalties', () => {
+      beforeEach(() => {
+        httpClientStub
+          .withArgs('groupPayment/', {
+            TotalAmount: 120,
+            PaymentMethod: 'CNP',
+            VehicleRegistration: '11DDD',
+            PenaltyGroupId: '5624r2wupfs',
+            PenaltyType: 'FPN',
+            RedirectUrl: 'http://redirect.url',
+            Penalties: [
+              {
+                PenaltyReference: '564548184556',
+                PenaltyAmount: 100,
+                VehicleRegistration: '11DDD',
+              },
+              {
+                PenaltyReference: '5281756140484',
+                PenaltyAmount: 20,
+                VehicleRegistration: '11DDD',
+              },
+            ],
+          })
+          .resolves('resolved value');
+      });
+
+      it('should return POST promise from groupCardNotPresent endpoint', async () => {
+        const resolution = await cpmsService.createCardNotPresentGroupTransaction(
+          '5624r2wupfs',
+          penaltyGroup.penaltyGroupDetails,
+          'FPN',
+          penaltyGroup.penaltyDetails[0].penalties,
+          'http://redirect.url',
+        );
+        expect(resolution).to.equal('resolved value');
+      });
     });
-    afterEach(() => {
-      HttpClient.prototype.post.restore();
-    });
-    
-    it('should return POST promise from groupCardNotPresent endpoint', async () => {
-      const resolution = await cpmsService.createCardNotPresentGroupTransaction(
-        '5624r2wupfs',
-        penaltyGroup.penaltyGroupDetails,
-        'FPN',
-        penaltyGroup.penaltyDetails[0].penalties,
-        'http://redirect.url',
-      );
-      expect(resolution).to.equal('resolved value');
+
+    context('for an immobilisation', () => {
+      beforeEach(() => {
+        httpClientStub
+          .withArgs('groupPayment/', {
+            TotalAmount: 80,
+            PaymentMethod: 'CNP',
+            VehicleRegistration: '11DDD',
+            PenaltyGroupId: '5624r2wupfs',
+            PenaltyType: 'IM',
+            RedirectUrl: 'http://redirect.url',
+            Penalties: [
+              {
+                PenaltyReference: '54663-0-441-IM',
+                PenaltyAmount: 80,
+                VehicleRegistration: '11DDD',
+              },
+            ],
+          })
+          .resolves('resolved value');
+      });
+      it('should return POST promise for groupCardNotPresent endpoint', async () => {
+        const resolution = await cpmsService.createCardNotPresentGroupTransaction(
+          '5624r2wupfs',
+          penaltyGroup.penaltyGroupDetails,
+          'IM',
+          penaltyGroup.penaltyDetails[1].penalties,
+          'http://redirect.url',
+        );
+        expect(resolution).to.equal('resolved value');
+      });
     });
   });
 
   describe('createGroupCashTransaction', () => {
-    const penaltyGroup = fakePenaltyGroups.find(group => group.paymentCode === '5624r2wupfs');
-    beforeEach(() => {
-      httpClientStub = sinon.stub(HttpClient.prototype, 'post');
-      httpClientStub
-        .withArgs('groupPayment/', {
-          TotalAmount: 120,
-          PaymentMethod: 'CASH',
-          VehicleRegistration: '11DDD',
-          PenaltyGroupId: '5624r2wupfs',
-          PenaltyType: 'FPN',
-          SlipNumber: '1234',
-          BatchNumber: '1234',
-          ReceiptDate: new Date().toISOString().split('T')[0],
-          RedirectUrl: 'https://redirect.url',
-          Penalties: [
-            {
-              PenaltyReference: '564548184556',
-              PenaltyAmount: 100,
-              VehicleRegistration: '11DDD',
-            },
-            {
-              PenaltyReference: '5281756140484',
-              PenaltyAmount: 20,
-              VehicleRegistration: '11DDD',
-            },
-          ],
-        })
-        .resolves('resolved value');
+    context('for a group of fixed penalties', () => {
+      beforeEach(() => {
+        httpClientStub
+          .withArgs('groupPayment/', {
+            TotalAmount: 120,
+            PaymentMethod: 'CASH',
+            VehicleRegistration: '11DDD',
+            PenaltyGroupId: '5624r2wupfs',
+            PenaltyType: 'FPN',
+            SlipNumber: '1234',
+            BatchNumber: '1234',
+            ReceiptDate: new Date().toISOString().split('T')[0],
+            RedirectUrl: 'https://redirect.url',
+            Penalties: [
+              {
+                PenaltyReference: '564548184556',
+                PenaltyAmount: 100,
+                VehicleRegistration: '11DDD',
+              },
+              {
+                PenaltyReference: '5281756140484',
+                PenaltyAmount: 20,
+                VehicleRegistration: '11DDD',
+              },
+            ],
+          })
+          .resolves('resolved value');
+      });
+      it('should return a POST promise from the groupCashPayment endpoint', async () => {
+        const resolution = await cpmsService.createGroupCashTransaction(
+          '5624r2wupfs',
+          penaltyGroup.penaltyGroupDetails,
+          'FPN',
+          penaltyGroup.penaltyDetails,
+          'https://redirect.url',
+          '1234',
+        );
+        expect(resolution).to.equal('resolved value');
+      });
     });
-    afterEach(() => {
-      HttpClient.prototype.post.restore();
-    });
-    it('should return a POST promise from the groupCashPayment endpoint', async () => {
-      const resolution = await cpmsService.createGroupCashTransaction(
-        '5624r2wupfs',
-        penaltyGroup.penaltyGroupDetails,
-        'FPN',
-        penaltyGroup.penaltyDetails,
-        'https://redirect.url',
-        '1234',
-      );
-      expect(resolution).to.equal('resolved value');
+
+    context('for an immobilisation', () => {
+      beforeEach(() => {
+        httpClientStub
+          .withArgs('groupPayment/', {
+            TotalAmount: 80,
+            PaymentMethod: 'CASH',
+            VehicleRegistration: '11DDD',
+            PenaltyGroupId: '5624r2wupfs',
+            PenaltyType: 'IM',
+            SlipNumber: '1234',
+            BatchNumber: '1234',
+            ReceiptDate: new Date().toISOString().split('T')[0],
+            RedirectUrl: 'https://redirect.url',
+            Penalties: [
+              {
+                PenaltyReference: '54663-0-441-IM',
+                PenaltyAmount: 80,
+                VehicleRegistration: '11DDD',
+              },
+            ],
+          })
+          .resolves('resolved value');
+      });
+      it('should return a POST promise from the groupCashPayment endpoint', async () => {
+        const resolution = await cpmsService.createGroupCashTransaction(
+          '5624r2wupfs',
+          penaltyGroup.penaltyGroupDetails,
+          'IM',
+          penaltyGroup.penaltyDetails,
+          'https://redirect.url',
+          '1234',
+        );
+        expect(resolution).to.equal('resolved value');
+      });
     });
   });
 
   describe('createGroupChequeTransaction', () => {
-    const penaltyGroup = fakePenaltyGroups.find(group => group.paymentCode === '5624r2wupfs');
-    beforeEach(() => {
-      httpClientStub = sinon.stub(HttpClient.prototype, 'post');
-      httpClientStub
-        .withArgs('groupPayment/', {
-          TotalAmount: 120,
-          PaymentMethod: 'CHEQUE',
-          VehicleRegistration: '11DDD',
-          PenaltyGroupId: '5624r2wupfs',
-          PenaltyType: 'FPN',
-          SlipNumber: '1234',
-          BatchNumber: '1234',
-          ReceiptDate: new Date().toISOString().split('T')[0],
-          ChequeNumber: '2468',
-          ChequeDate: sinon.match.date,
-          NameOnCheque: 'Joe Bloggs',
-          RedirectUrl: 'https://redirect.url',
-          Penalties: [
-            {
-              PenaltyReference: '564548184556',
-              PenaltyAmount: 100,
-              VehicleRegistration: '11DDD',
-            },
-            {
-              PenaltyReference: '5281756140484',
-              PenaltyAmount: 20,
-              VehicleRegistration: '11DDD',
-            },
-          ],
-        })
-        .resolves('resolved value');
+    context('for a group of fixed penalties', () => {
+      beforeEach(() => {
+        httpClientStub
+          .withArgs('groupPayment/', {
+            TotalAmount: 120,
+            PaymentMethod: 'CHEQUE',
+            VehicleRegistration: '11DDD',
+            PenaltyGroupId: '5624r2wupfs',
+            PenaltyType: 'FPN',
+            SlipNumber: '1234',
+            BatchNumber: '1234',
+            ReceiptDate: new Date().toISOString().split('T')[0],
+            ChequeNumber: '2468',
+            ChequeDate: sinon.match.date,
+            NameOnCheque: 'Joe Bloggs',
+            RedirectUrl: 'https://redirect.url',
+            Penalties: [
+              {
+                PenaltyReference: '564548184556',
+                PenaltyAmount: 100,
+                VehicleRegistration: '11DDD',
+              },
+              {
+                PenaltyReference: '5281756140484',
+                PenaltyAmount: 20,
+                VehicleRegistration: '11DDD',
+              },
+            ],
+          })
+          .resolves('resolved value');
+      });
+      it('should return a POST promise from the groupPayment endpoint', async () => {
+        const resolution = await cpmsService.createGroupChequeTransaction(
+          '5624r2wupfs',
+          penaltyGroup.penaltyGroupDetails,
+          'FPN',
+          penaltyGroup.penaltyDetails,
+          'https://redirect.url',
+          '1234',
+          '2468',
+          new Date(),
+          'Joe Bloggs',
+        );
+        expect(resolution).to.equal('resolved value');
+      });
     });
-    afterEach(() => {
-      HttpClient.prototype.post.restore();
-    });
-    it('should return a POST promise from the groupPayment endpoint', async () => {
-      const resolution = await cpmsService.createGroupChequeTransaction(
-        '5624r2wupfs',
-        penaltyGroup.penaltyGroupDetails,
-        'FPN',
-        penaltyGroup.penaltyDetails,
-        'https://redirect.url',
-        '1234',
-        '2468',
-        new Date(),
-        'Joe Bloggs',
-      );
-      expect(resolution).to.equal('resolved value');
+
+    context('for an immobilisation', () => {
+      beforeEach(() => {
+        httpClientStub
+          .withArgs('groupPayment/', {
+            TotalAmount: 80,
+            PaymentMethod: 'CHEQUE',
+            VehicleRegistration: '11DDD',
+            PenaltyGroupId: '5624r2wupfs',
+            PenaltyType: 'IM',
+            SlipNumber: '1234',
+            BatchNumber: '1234',
+            ReceiptDate: new Date().toISOString().split('T')[0],
+            ChequeNumber: '2468',
+            ChequeDate: sinon.match.date,
+            NameOnCheque: 'Joe Bloggs',
+            RedirectUrl: 'https://redirect.url',
+            Penalties: [
+              {
+                PenaltyReference: '54663-0-441-IM',
+                PenaltyAmount: 80,
+                VehicleRegistration: '11DDD',
+              },
+            ],
+          })
+          .resolves('resolved value');
+      });
+      it('should return a POST promise from the groupPayment endpoint', async () => {
+        const resolution = await cpmsService.createGroupChequeTransaction(
+          '5624r2wupfs',
+          penaltyGroup.penaltyGroupDetails,
+          'IM',
+          penaltyGroup.penaltyDetails,
+          'https://redirect.url',
+          '1234',
+          '2468',
+          new Date(),
+          'Joe Bloggs',
+        );
+        expect(resolution).to.equal('resolved value');
+      });
     });
   });
 
   describe('createGroupPostalOrderTransaction', () => {
-    const penaltyGroup = fakePenaltyGroups.find(group => group.paymentCode === '5624r2wupfs');
-    beforeEach(() => {
-      httpClientStub = sinon.stub(HttpClient.prototype, 'post');
-      httpClientStub
-        .withArgs('groupPayment/', {
-          TotalAmount: 120,
-          PaymentMethod: 'POSTAL_ORDER',
-          VehicleRegistration: '11DDD',
-          PenaltyGroupId: '5624r2wupfs',
-          PenaltyType: 'FPN',
-          SlipNumber: '1234',
-          BatchNumber: '1234',
-          PostalOrderNumber: '2468',
-          ReceiptDate: new Date().toISOString().split('T')[0],
-          RedirectUrl: 'https://redirect.url',
-          Penalties: [
-            {
-              PenaltyReference: '564548184556',
-              PenaltyAmount: 100,
-              VehicleRegistration: '11DDD',
-            },
-            {
-              PenaltyReference: '5281756140484',
-              PenaltyAmount: 20,
-              VehicleRegistration: '11DDD',
-            },
-          ],
-        })
-        .resolves('resolved value');
+    context('for a group of fixed penalties', () => {
+      beforeEach(() => {
+        httpClientStub
+          .withArgs('groupPayment/', {
+            TotalAmount: 120,
+            PaymentMethod: 'POSTAL_ORDER',
+            VehicleRegistration: '11DDD',
+            PenaltyGroupId: '5624r2wupfs',
+            PenaltyType: 'FPN',
+            SlipNumber: '1234',
+            BatchNumber: '1234',
+            PostalOrderNumber: '2468',
+            ReceiptDate: new Date().toISOString().split('T')[0],
+            RedirectUrl: 'https://redirect.url',
+            Penalties: [
+              {
+                PenaltyReference: '564548184556',
+                PenaltyAmount: 100,
+                VehicleRegistration: '11DDD',
+              },
+              {
+                PenaltyReference: '5281756140484',
+                PenaltyAmount: 20,
+                VehicleRegistration: '11DDD',
+              },
+            ],
+          })
+          .resolves('resolved value');
+      });
+      it('should return a POST promise from the groupPayment endpoint', async () => {
+        const resolution = await cpmsService.createGroupPostalOrderTransaction(
+          '5624r2wupfs',
+          penaltyGroup.penaltyGroupDetails,
+          'FPN',
+          penaltyGroup.penaltyDetails,
+          'https://redirect.url',
+          '1234',
+          '2468',
+        );
+        expect(resolution).to.equal('resolved value');
+      });
     });
-    afterEach(() => {
-      HttpClient.prototype.post.restore();
-    });
-    it('should return a POST promise from the groupPayment endpoint', async () => {
-      const resolution = await cpmsService.createGroupPostalOrderTransaction(
-        '5624r2wupfs',
-        penaltyGroup.penaltyGroupDetails,
-        'FPN',
-        penaltyGroup.penaltyDetails,
-        'https://redirect.url',
-        '1234',
-        '2468',
-      );
-      expect(resolution).to.equal('resolved value');
+
+    context('for an immobilisation', () => {
+      beforeEach(() => {
+        httpClientStub
+          .withArgs('groupPayment/', {
+            TotalAmount: 80,
+            PaymentMethod: 'POSTAL_ORDER',
+            VehicleRegistration: '11DDD',
+            PenaltyGroupId: '5624r2wupfs',
+            PenaltyType: 'IM',
+            SlipNumber: '1234',
+            BatchNumber: '1234',
+            PostalOrderNumber: '2468',
+            ReceiptDate: new Date().toISOString().split('T')[0],
+            RedirectUrl: 'https://redirect.url',
+            Penalties: [
+              {
+                PenaltyReference: '54663-0-441-IM',
+                PenaltyAmount: 80,
+                VehicleRegistration: '11DDD',
+              },
+            ],
+          })
+          .resolves('resolved value');
+      });
+      it('should return a POST promise from the groupPayment endpoint', async () => {
+        const resolution = await cpmsService.createGroupPostalOrderTransaction(
+          '5624r2wupfs',
+          penaltyGroup.penaltyGroupDetails,
+          'IM',
+          penaltyGroup.penaltyDetails,
+          'https://redirect.url',
+          '1234',
+          '2468',
+        );
+        expect(resolution).to.equal('resolved value');
+      });
     });
   });
 });


### PR DESCRIPTION
* Ensure that we use `formattedReference` field from parsed single penalties, as opposed to `reference` field