### PR TITLE
Fix issue search for vehicle reg in partial paid cancellation group

### DIFF
--- a/src/server/controllers/main.controller.js
+++ b/src/server/controllers/main.controller.js
@@ -138,10 +138,19 @@ const summarisePenaltyGroup = (penaltyGroup) => {
     const type = id.split('_')[1];
     return type === 'IM' ? 'immobilisation' : 'penalty';
   });
-  const penaltyLabel = grouping.penalty.length === 1 ? 'penalty' : 'penalties';
-  const penaltyDesc = `${grouping.penalty.length} ${penaltyLabel}`;
-  const afterPenaltyDesc = grouping.immobilisation !== undefined ? ' + immobilisation' : '';
-  return `${penaltyDesc}${afterPenaltyDesc}`;
+  const bothTypesPresent = grouping.immobilisation && grouping.penalty;
+  let penaltyDesc = '';
+  if (grouping.penalty) {
+    const numPenalties = grouping.penalty.length;
+    penaltyDesc = `${numPenalties} ${grouping.penalty.length === 1 ? 'penalty' : 'penalties'}`;
+  }
+  let immobDesc = '';
+  if (grouping.immobilisation) {
+    const imNumberingMaybeApplied = bothTypesPresent ? 'immobilisation' : '1 immobilisation';
+    immobDesc = grouping.immobilisation ? imNumberingMaybeApplied : '';
+  }
+  const separator = bothTypesPresent ? ' + ' : '';
+  return `${penaltyDesc}${separator}${immobDesc}`;
 };
 
 const summarisePenalty = (penalty) => {

--- a/test/controllers/main.controller.spec.js
+++ b/test/controllers/main.controller.spec.js
@@ -159,6 +159,52 @@ describe('MainController', () => {
       });
     });
 
+    context('when we search for a reg in a penalty group with only one FPN', () => {
+      it('should render correctly', async () => {
+        searchForm.vehicle_reg = '11EEE';
+        await MainController.searchPenalty(request, response);
+        await MainController.searchVehicleReg({ params: { vehicle_reg: '11EEE' } }, response);
+
+        const expectedViewData = {
+          vehicleReg: '11EEE',
+          results: [
+            {
+              paymentCode: 'abc123',
+              paymentStatus: 'UNPAID',
+              summary: '1 penalty',
+              date: 1535546734.879,
+              formattedDate: '29/08/2018 13:45',
+            },
+          ],
+        };
+        sinon.assert.calledWith(redirectSpy, '/vehicle-reg-search-results/11EEE');
+        sinon.assert.calledWith(renderSpy, 'penalty/vehicleRegSearchResults', expectedViewData);
+      });
+    });
+
+    context('when we search for a reg in a penalty group with only one IM', () => {
+      it('should render correctly', async () => {
+        searchForm.vehicle_reg = '11FFF';
+        await MainController.searchPenalty(request, response);
+        await MainController.searchVehicleReg({ params: { vehicle_reg: '11FFF' } }, response);
+
+        const expectedViewData = {
+          vehicleReg: '11FFF',
+          results: [
+            {
+              paymentCode: 'abc123',
+              paymentStatus: 'UNPAID',
+              summary: '1 immobilisation',
+              date: 1535546734.879,
+              formattedDate: '29/08/2018 13:45',
+            },
+          ],
+        };
+        sinon.assert.calledWith(redirectSpy, '/vehicle-reg-search-results/11FFF');
+        sinon.assert.calledWith(renderSpy, 'penalty/vehicleRegSearchResults', expectedViewData);
+      });
+    });
+
     context('when the user searches for a blank registration', () => {
       it('should redirect back home with the invalid registration query param', async () => {
         searchForm.vehicle_reg = '   ';

--- a/test/data/registrationSearch/registrationSearchResponses.js
+++ b/test/data/registrationSearch/registrationSearchResponses.js
@@ -168,4 +168,44 @@ export default {
       },
     ],
   },
+  '11EEE': {
+    PenaltyGroups: [
+      {
+        ID: 'abc123',
+        Enabled: true,
+        SiteCode: 19,
+        TotalAmount: 888,
+        PaymentStatus: 'UNPAID',
+        Offset: 1533562273.803,
+        Location: 'Dalar Hir (A55 near Holyhead)',
+        VehicleRegistration: '11EEE',
+        Origin: 'APP',
+        Timestamp: 1535546734.879,
+        PenaltyDocumentIds: [
+          '123_FPN',
+        ],
+      },
+    ],
+    Penalties: [],
+  },
+  '11FFF': {
+    PenaltyGroups: [
+      {
+        ID: 'abc123',
+        Enabled: true,
+        SiteCode: 19,
+        TotalAmount: 80,
+        PaymentStatus: 'UNPAID',
+        Offset: 1533562273.803,
+        Location: 'Dalar Hir (A55 near Holyhead)',
+        VehicleRegistration: '11FFF',
+        Origin: 'APP',
+        Timestamp: 1535546734.879,
+        PenaltyDocumentIds: [
+          '123_IM',
+        ],
+      },
+    ],
+    Penalties: [],
+  },
 };


### PR DESCRIPTION
* Assumptions were made that all penalty groups would contain at least
  two penalties
* Now we have allowed for cancellation of partly paid penalty groups by
  removing the unpaid part, we can have penalty groups consisting of a
  single penalty
* Fix reg search code to accomodate this