### PR TITLE
adds contact centre staff to list of approved roles for reports

### DIFF
--- a/src/server/middlewares/financeUsersAuthorization.middleware.js
+++ b/src/server/middlewares/financeUsersAuthorization.middleware.js
@@ -1,16 +1,17 @@
 import { intersection } from 'lodash';
 import config from '../config';
 
-const authorizedRoles = ['BankingFinance'];
+const reversePaymentAuthorizedRoles = ['BankingFinance'];
+const reportsAuthorizedRoles = ['BankingFinance', 'ContactCentre'];
 
-export default (req, res, next) => {
+const reversePaymentAuthorizer = (req, res, next) => {
   if (config.doRoleChecks()) {
     const userRole = req.session.rsp_user_role;
     if (userRole) {
       if (typeof userRole === 'string') {
-        if (authorizedRoles.includes(userRole)) return next();
+        if (reversePaymentAuthorizedRoles.includes(userRole)) return next();
       } else {
-        const matchedRoles = intersection(authorizedRoles, userRole);
+        const matchedRoles = intersection(reversePaymentAuthorizedRoles, userRole);
         if (matchedRoles.length) return next();
       }
       // User doesn't have an authorized role, forbid access
@@ -20,4 +21,28 @@ export default (req, res, next) => {
     return res.render('main/forbidden', req.session);
   }
   return next();
+};
+
+const reportsAuthorizer = (req, res, next) => {
+  if (config.doRoleChecks()) {
+    const userRole = req.session.rsp_user_role;
+    if (userRole) {
+      if (typeof userRole === 'string') {
+        if (reportsAuthorizedRoles.includes(userRole)) return next();
+      } else {
+        const matchedRoles = intersection(reportsAuthorizedRoles, userRole);
+        if (matchedRoles.length) return next();
+      }
+      // User doesn't have an authorized role, forbid access
+      return res.render('main/forbidden', req.session);
+    }
+    // User doesn't have an authorized role, forbid access
+    return res.render('main/forbidden', req.session);
+  }
+  return next();
+};
+
+export default {
+  reversePaymentAuthorizer,
+  reportsAuthorizer,
 };

--- a/src/server/routes.js
+++ b/src/server/routes.js
@@ -6,7 +6,7 @@ import * as paymentController from './controllers/payment.controller';
 import * as penaltyController from './controllers/penalty.controller';
 import * as reportController from './controllers/report.controller';
 import receiptController from './controllers/receipt.controller';
-import financeUsersAuthorizationMiddleware from './middlewares/financeUsersAuthorization.middleware';
+import { reportsAuthorizer, reversePaymentAuthorizer } from './middlewares/financeUsersAuthorization.middleware';
 
 const router = Router();
 
@@ -30,8 +30,8 @@ router.post('/payment-code/:payment_code/payment', paymentCodeController.validat
 router.post('/payment-code/:payment_code/:type/payment', paymentController.makeGroupPayment);
 router.get('/payment-code/:payment_code/confirmPayment', paymentController.confirmPayment);
 router.get('/payment-code/:payment_code/:type/confirmGroupPayment', paymentController.confirmGroupPayment);
-router.post('/payment-code/:payment_code/reversePayment', financeUsersAuthorizationMiddleware, paymentController.reversePayment);
-router.post('/payment-code/:payment_code/:type/reverseGroupPayment', financeUsersAuthorizationMiddleware, paymentController.reverseGroupPayment);
+router.post('/payment-code/:payment_code/reversePayment', reversePaymentAuthorizer, paymentController.reversePayment);
+router.post('/payment-code/:payment_code/:type/reverseGroupPayment', reversePaymentAuthorizer, paymentController.reverseGroupPayment);
 router.get('/payment-code/:payment_code/:type/details', paymentCodeController.getPenaltyGroupBreakdownForType);
 router.get('/payment-code/:payment_code/:type/receipt', receiptController);
 
@@ -41,10 +41,10 @@ router.post('/penalty/:penalty_id/cancel', penaltyController.cancelPenalty);
 router.get('/penalty/:penalty_id/payment', paymentController.renderPaymentPage);
 
 // Reports
-router.get('/reports', authorizationMiddleware, financeUsersAuthorizationMiddleware, reportController.renderReportFilters);
-router.post('/reports', financeUsersAuthorizationMiddleware, reportController.generateReport);
-router.get('/reports/:report_ref/', financeUsersAuthorizationMiddleware, reportController.showDetails);
-router.get('/reports/:report_ref/status', financeUsersAuthorizationMiddleware, reportController.checkReportStatus);
-router.get('/reports/:report_ref/download', financeUsersAuthorizationMiddleware, reportController.downloadReport);
+router.get('/reports', authorizationMiddleware, reportsAuthorizer, reportController.renderReportFilters);
+router.post('/reports', reportsAuthorizer, reportController.generateReport);
+router.get('/reports/:report_ref/', reportsAuthorizer, reportController.showDetails);
+router.get('/reports/:report_ref/status', reportsAuthorizer, reportController.checkReportStatus);
+router.get('/reports/:report_ref/download', reportsAuthorizer, reportController.downloadReport);
 
 export default router;


### PR DESCRIPTION
- Splits the finance users authorizer into two: `reversePaymentAuthorizedRoles` and `reportsAuthorizedRoles`
- Allows `ContactCentre` role to access reports. 