### PR TITLE
RSP-1654: Remove the ability to take a cheque/postal order payment for immobilisations

### DIFF
--- a/src/server/controllers/payment.controller.js
+++ b/src/server/controllers/payment.controller.js
@@ -255,7 +255,7 @@ export const renderPaymentPage = async (req, res) => {
     const redirectUrl = `${config.postPaymentRedirectBaseUrl()}/payment-code/${paymentCode}/confirmPayment`;
 
     if (!validPaymentTypeForPenaltyType(paymentType, penaltyDetails.type)) {
-      return res.redirect('./');
+      return res.redirect(`${config.urlRoot()}/payment-code/${paymentCode}`);
     }
 
     switch (paymentType) {

--- a/src/server/controllers/payment.controller.js
+++ b/src/server/controllers/payment.controller.js
@@ -167,6 +167,11 @@ export const makeGroupPayment = async (req, res) => {
   try {
     const penaltyType = req.params.type;
     const { paymentType } = req.body;
+
+    if (!validPaymentTypeForPenaltyType(paymentType, penaltyType)) {
+      return res.redirect(`${config.urlRoot()}/payment-code/${paymentCode}`);
+    }
+
     const penaltyGroup = await penaltyGroupService.getByPaymentCode(paymentCode);
     const penaltiesOfType = penaltyGroup.penaltyDetails.find(p => p.type === penaltyType).penalties;
     const amountPaidForType = penaltyGroup.penaltyGroupDetails.splitAmounts
@@ -302,6 +307,10 @@ export const renderGroupPaymentPage = async (req, res) => {
 
     if (penaltyGroup.paymentStatus === 'PAID') {
       return res.redirect(`${config.urlRoot()}/payment-code/${paymentCode}`);
+    }
+
+    if (!validPaymentTypeForPenaltyType(paymentType, penaltyType)) {
+      return res.redirect(`${config.urlRoot()}/payment-code/${paymentCode}/${penaltyType}/details`);
     }
 
     if (paymentType === 'card') {

--- a/src/server/views/payment/penaltyGroupTypeBreakdown.njk
+++ b/src/server/views/payment/penaltyGroupTypeBreakdown.njk
@@ -60,8 +60,10 @@
             {{ components.heading(text='Payment by', tag='h3', size='medium') }}
             {{ components.radio(text='Card (external website)', value='card', id='pay-by-card', name='paymentType', checked="true") }}
             {{ components.radio(text='Cash', value='cash', id='pay-by-cash', name='paymentType') }}
-            {{ components.radio(text='Cheque', value='cheque', id='pay-by-cheque', name='paymentType') }}
-            {{ components.radio(text='Postal Order', value='postal', id='pay-by-postal', name='paymentType') }}
+            {% if penaltyType !== 'IM' %}
+              {{ components.radio(text='Cheque', value='cheque', id='pay-by-cheque', name='paymentType') }}
+              {{ components.radio(text='Postal Order', value='postal', id='pay-by-postal', name='paymentType') }}
+            {% endif %}
           {%- endcall %}
           {{ components.button(text=submitButtonText, type='submit') }}
         {%- endcall %}

--- a/src/server/views/penalty/penaltyDetails.njk
+++ b/src/server/views/penalty/penaltyDetails.njk
@@ -111,8 +111,10 @@
               {{ components.heading(text='Payment by', tag='h3', size='medium') }}
               {{ components.radio(text='Card (external website)', value='card', id='pay-by-card', name='paymentType', checked="true") }}
               {{ components.radio(text='Cash', value='cash', id='pay-by-cash', name='paymentType') }}
-              {{ components.radio(text='Cheque', value='cheque', id='pay-by-cheque', name='paymentType') }}
-              {{ components.radio(text='Postal Order', value='postal', id='pay-by-postal', name='paymentType') }}
+              {% if type !== 'IM' %}
+                {{ components.radio(text='Cheque', value='cheque', id='pay-by-cheque', name='paymentType') }}
+                {{ components.radio(text='Postal Order', value='postal', id='pay-by-postal', name='paymentType') }}
+              {% endif %}
             {%- endcall %}
             {{ components.button(text='Continue to payment', type='submit') }}
           {%- endcall %}

--- a/test/data/penaltyServiceGetResponses.js
+++ b/test/data/penaltyServiceGetResponses.js
@@ -13,4 +13,18 @@ export default [
     typeDescription: 'immobilisation',
     enabled: true,
   },
+  {
+    complete: true,
+    reference: '379468752548',
+    paymentCode: '3cc571fbf9459417',
+    issueDate: '04/10/2018',
+    vehicleReg: 'TESTER4',
+    formattedReference: '379468752548',
+    location: 'Sandbach (Sandbach Services M6 just South of J17)',
+    amount: 120,
+    status: 'UNPAID',
+    type: 'FPN',
+    typeDescription: 'Fixed Penalty Notice',
+    enabled: true,
+  },
 ];


### PR DESCRIPTION
Remove the ability to take a cheque/postal order payment for immobilisations.

- Remove the radio buttons for payments/group payments
- Redirect on attempted invalid payment/group payment