### PR TITLE
RSP 1544: Move penalty details out of summary

### DIFF
--- a/src/server/views/penalty/penaltyGroupSummary.njk
+++ b/src/server/views/penalty/penaltyGroupSummary.njk
@@ -124,53 +124,45 @@
 
       {% for penaltyType in penaltyDetails %}
         {% if penaltyType.type == 'FPN' %}
-          <p>
-            <details>
-              <summary><span class="summary">See fixed penalty details</span></summary>
-              <div class="panel panel-border-narrow">
-                <table>
-                  <thead>
-                    <tr>
-                      <th>Reference</th>
-                      <th>Amount</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {% for penalty in penaltyType.penalties %}
-                      <tr>
-                        <td>{{ penalty.formattedReference }}</td>
-                        <td>&pound;{{ penalty.amount }}</td>
-                      </tr>
-                    {% endfor %}
-                  </tbody>
-                </table>
-              </div>
-            </details>    
-          </p>
+          <div>
+            {{ components.heading(text='Fixed penalty details', tag='h3', size='medium') }}
+            <table>
+              <thead>
+                <tr>
+                  <th>Reference</th>
+                  <th>Amount</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for penalty in penaltyType.penalties %}
+                  <tr>
+                    <td>{{ penalty.formattedReference }}</td>
+                    <td>&pound;{{ penalty.amount }}</td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
         {% elif penaltyType.type == 'CDN' %}
-          <p>
-            <details>
-              <summary><span class="summary">See court deposit details</span></summary>
-              <div class="panel panel-border-narrow">
-                <table>
-                  <thead>
-                    <tr>
-                      <th>Reference</th>
-                      <th>Amount</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {% for penalty in penaltyType.penalties %}
-                      <tr>
-                        <td>{{ penalty.formattedReference }}</td>
-                        <td>&pound;{{ penalty.amount }}</td>
-                      </tr>
-                    {% endfor %}
-                  </tbody>
-                </table>
-              </div>
-            </details>    
-          </p>
+          <div>
+            {{ components.heading(text='Court deposity details', tag='h3', size='medium') }}
+            <table>
+              <thead>
+                <tr>
+                  <th>Reference</th>
+                  <th>Amount</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for penalty in penaltyType.penalties %}
+                  <tr>
+                    <td>{{ penalty.formattedReference }}</td>
+                    <td>&pound;{{ penalty.amount }}</td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
         {% endif %}
       {% endfor %}
     {%- endcall %}


### PR DESCRIPTION
# Previously

Fixed penalties and court deposit references were previously contained in a summary

<img width="678" alt="screen shot 2018-12-12 at 11 55 18" src="https://user-images.githubusercontent.com/44976690/49868279-dca62380-fe04-11e8-83da-a291d2950509.png">
<img width="658" alt="screen shot 2018-12-12 at 11 56 09" src="https://user-images.githubusercontent.com/44976690/49868311-f21b4d80-fe04-11e8-8e91-499f15f8c18a.png">

# Now

Fixed penalties and court deposit references are now always visible

<img width="653" alt="screen shot 2018-12-12 at 11 56 55" src="https://user-images.githubusercontent.com/44976690/49868341-0fe8b280-fe05-11e8-8ad5-4cd06355d9ac.png">
