### PR TITLE
RSP-1547: Change cancelled status colour

### DIFF
--- a/src/public/scss/gds/variables/partials/_palette-colours.scss
+++ b/src/public/scss/gds/variables/partials/_palette-colours.scss
@@ -74,4 +74,5 @@ $beta-colour: $govuk-blue;        // Beta badges and banners
 $live-colour: $grass-green;       // Live badges and banners
 $banner-text-colour: #000;        // Text colour for Alpha & Beta banners
 $error-colour: $red;              // Error text and border colour
+$cancelled-colour: #f5a623;
 $error-background: #fef7f7;       // Error background colour

--- a/src/public/scss/styles.scss
+++ b/src/public/scss/styles.scss
@@ -60,6 +60,10 @@ table#receipt-breakdown {
   color: $error-colour;
 }
 
+.cancelled {
+  color: $cancelled-colour;
+}
+
 .confirmed {
   color: #00823B;
 }

--- a/src/server/views/penalty/vehicleRegSearchResults.njk
+++ b/src/server/views/penalty/vehicleRegSearchResults.njk
@@ -23,7 +23,15 @@
           <tr>
             <td>{{ components.link(text=result.paymentCode, url='/payment-code/' + result.paymentCode) }}</td>
             <td>{{ result.formattedDate }}</td>
-              {% set statusClass = 'confirmed' if result.paymentStatus == 'PAID' else 'unconfirmed' %}
+
+              {% if result.paymentStatus == 'PAID' %}
+                {% set statusClass = 'confirmed' %}
+              {% elif result.paymentStatus == 'CANCELLED' %}
+                {% set statusClass = 'cancelled' %}
+              {% else %}
+                {% set statusClass = 'unconfirmed' %}
+              {% endif %}
+
               <td><span class='{{statusClass}}'><strong>{{ result.paymentStatus }}</strong></span></td>
             <td>{{ result.summary }}</td>
           </tr>


### PR DESCRIPTION
Change the cancelled status colour to #f5a623 (orange) in the vehicle registration search view. The status is shown as 'UNPAID' or 'PAID' on the penalty details pages so has not been changed there.