### PR TITLE
RSP-1740: Remove inline JS from payment code cancellation

### DIFF
--- a/src/public/scss/styles.scss
+++ b/src/public/scss/styles.scss
@@ -82,6 +82,21 @@ table#receipt-breakdown {
   background-color: #454A4C;
 }
 
+.cancel-payment-code {
+  background: none;
+  border: none;
+  color: #005ea5;
+  text-decoration: underline;
+  cursor: pointer;
+  padding: 0;
+  margin: 0;
+  display: inline-block;
+  vertical-align: middle;
+  white-space: normal;
+  background: none;
+  line-height: 1;
+}
+
 .right {
   float: right; 
 }

--- a/src/server/views/layouts/partials/head.njk
+++ b/src/server/views/layouts/partials/head.njk
@@ -17,7 +17,7 @@
 <!-- /head-misc -->
 
 <!-- stylesheets -->
-<link href="{{ assets }}/stylesheets/styles.css" media="all" rel="stylesheet" />
+<link href="{{ assets }}/stylesheets/styles.css?version=2019.02.08" media="all" rel="stylesheet" />
 <!-- /stylesheets -->
 
 <!--[if lt IE 9]>

--- a/src/server/views/penalty/penaltyDetails.njk
+++ b/src/server/views/penalty/penaltyDetails.njk
@@ -129,7 +129,7 @@
         {{ components.heading(text='Additional actions', tag='h3', size='medium') }}
         <nav role="navigation" aria-labelledby="subsection-title">
           <form id="other-actions-form" action="{{urlroot}}/penalty/{{reference}}_{{type}}/cancel" method="POST">
-            <a href="#" onclick="document.getElementById('other-actions-form').submit();">Cancel payment code</a>
+            <input type="submit" class="cancel-payment-code" value="Cancel payment code" />
         </form>
         </nav>
       </aside>

--- a/src/server/views/penalty/penaltyGroupSummary.njk
+++ b/src/server/views/penalty/penaltyGroupSummary.njk
@@ -172,7 +172,7 @@
           {{ components.heading(text='Additional actions', tag='h3', size='medium') }}
           <nav role="navigation" aria-labelledby="subsection-title">
             <form id="other-actions-form" action="{{urlroot}}/payment-code/{{paymentCode}}/cancel" method="POST">
-              <a href="#" onclick="document.getElementById('other-actions-form').submit();">Cancel payment code</a>
+              <input type="submit" class="cancel-payment-code" value="Cancel payment code" />
           </form>
           </nav>
         </aside>


### PR DESCRIPTION
Replace `<a>` tag with `<input type="submit"... />`. Inline JS was blocked by the content security policy. Styled input as link so no visual changes have been made.