### PR TITLE
Fix radio input selector for Safari

### DIFF
--- a/src/public/js/dvsa/gds/modules/show-hide-content/index.js
+++ b/src/public/js/dvsa/gds/modules/show-hide-content/index.js
@@ -45,7 +45,7 @@ export class ShowHideContent {
         let radioGroupName = event.target.getAttribute('name');
         // Refresh all radios for this group
         if (radioGroupName) {
-          let radioInputsForGroup = $$('input[type="radio"][name="' + radioGroupName + '"');
+          let radioInputsForGroup = Array.from(document.querySelectorAll(this.radioSelector));
           radioInputsForGroup.forEach(radio => {
             this.toggleContentBasedOnCheckState(radio);
           });


### PR DESCRIPTION
Applied patch from latest version of DVSA front end:

https://github.com/dvsa/front-end/blob/2f051593b3a10274ec099344d052e6f88c7a4ac6/src/assets/js/shared/gds/modules/show-hide-content/index.js#L16