### PR TITLE
RSP-1623: Receipt code missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ typings/
 dist/
 build/
 .serverless/
+
+.vscode

--- a/src/server/controllers/receipt.controller.js
+++ b/src/server/controllers/receipt.controller.js
@@ -29,6 +29,7 @@ export default async (req, res) => {
       paymentDetails: enrichedPaymentDetails,
       ...penaltyGroup,
     };
+    console.log({ ...resp, ...req.session });
     return res.render('payment/multiPaymentReceipt', { ...resp, ...req.session });
   } catch (error) {
     logger.error(error);

--- a/src/server/controllers/receipt.controller.js
+++ b/src/server/controllers/receipt.controller.js
@@ -29,7 +29,6 @@ export default async (req, res) => {
       paymentDetails: enrichedPaymentDetails,
       ...penaltyGroup,
     };
-    console.log({ ...resp, ...req.session });
     return res.render('payment/multiPaymentReceipt', { ...resp, ...req.session });
   } catch (error) {
     logger.error(error);

--- a/src/server/utils/dateTimeFormat.js
+++ b/src/server/utils/dateTimeFormat.js
@@ -1,4 +1,4 @@
-export const MOMENT_TIME_FORMAT = 'h:mma';
+export const MOMENT_TIME_FORMAT = 'HH:mm';
 export const MOMENT_DATE_FORMAT = 'DD/MM/YYYY';
 export const MOMENT_DATE_TIME_FORMAT = 'DD/MM/YYYY HH:mm';
 export const MOMENT_TIMEZONE = 'Europe/London';

--- a/src/server/views/payment/groupCash.njk
+++ b/src/server/views/payment/groupCash.njk
@@ -23,8 +23,8 @@
               <td>{{ penaltyGroupDetails.registrationNumber }}</td>
             </tr>
             <tr>
-              <td>Date issued:</td>
-              <td>{{ penaltyGroupDetails.date }}</td>
+              <td>Payment code issued at:</td>
+              <td>{{ penaltyGroupDetails.dateTime }}</td>
             </tr>
             <tr>
               <td>Location:</td>

--- a/src/server/views/payment/groupCheque.njk
+++ b/src/server/views/payment/groupCheque.njk
@@ -23,8 +23,8 @@
               <td>{{ penaltyGroupDetails.registrationNumber }}</td>
             </tr>
             <tr>
-              <td>Date issued:</td>
-              <td>{{ penaltyGroupDetails.date }}</td>
+              <td>Payment code issued at:</td>
+              <td>{{ penaltyGroupDetails.dateTime }}</td>
             </tr>
             <tr>
               <td>Location:</td>

--- a/src/server/views/payment/groupPostalOrder.njk
+++ b/src/server/views/payment/groupPostalOrder.njk
@@ -23,8 +23,8 @@
               <td>{{ penaltyGroupDetails.registrationNumber }}</td>
             </tr>
             <tr>
-              <td>Date issued:</td>
-              <td>{{ penaltyGroupDetails.date }}</td>
+              <td>Payment code issued at:</td>
+              <td>{{ penaltyGroupDetails.dateTime }}</td>
             </tr>
             <tr>
               <td>Location:</td>

--- a/src/server/views/payment/multiPaymentReceipt.njk
+++ b/src/server/views/payment/multiPaymentReceipt.njk
@@ -107,7 +107,7 @@
           </tr>
           <tr>
             <td>Date</td>
-            <td><strong>{{ penaltyGroupDetails.date }}</strong></td>
+            <td><strong>{{ penaltyGroupDetails.dateTime }}</strong></td>
           </tr>
           <tr>
             <td>Location</td>

--- a/src/server/views/payment/multiPaymentReceipt.njk
+++ b/src/server/views/payment/multiPaymentReceipt.njk
@@ -43,6 +43,12 @@
               </strong>
             </td>
           </tr>
+          <tr>
+            <td>Receipt code</td>
+              <td>
+                <strong>{{ paymentDetails.Payments[paymentType].PaymentRef }}</strong>
+              </td>
+          </tr>
           {% if paymentDetails.Payments[paymentType].PaymentMethod == 'CNP' %}
             <tr>
               <td>Payment method</td>

--- a/test/controllers/receipt.controller.spec.js
+++ b/test/controllers/receipt.controller.spec.js
@@ -62,7 +62,7 @@ describe('ReceiptController', () => {
               PaymentAmount: '80',
               PaymentDate: 1519300376,
               FormattedDate: '22/02/2018',
-              FormattedTime: '11:52am',
+              FormattedTime: '11:52',
               PaymentStatus: 'PAID',
             },
           },


### PR DESCRIPTION
### Receipt page

- Add CPMS reference
- Add missing create date/time

<img width="698" alt="Screen Shot 2019-03-21 at 16 39 45" src="https://user-images.githubusercontent.com/44976690/54769055-5f0a6480-4bf8-11e9-84a2-bc0cb070e441.png">

### Multi penalty non-card payment pages

- Added create date/time to cash, cheque and postal order payment pages

<img width="712" alt="Screen Shot 2019-03-21 at 16 42 32" src="https://user-images.githubusercontent.com/44976690/54769354-eeb01300-4bf8-11e9-95db-426e7c83aa50.png">
