### PR TITLE
RSP-1820: Disable double click on pay

### DIFF
--- a/src/public/js/disable-button-on-click.js
+++ b/src/public/js/disable-button-on-click.js
@@ -1,0 +1,10 @@
+{
+  const button = document.getElementById('confirm-payment-button');
+
+  button.addEventListener('click', function() {
+    window.setTimeout(() => {
+      button.className = button.className + ' disabled';
+      button.setAttribute('disabled', true);
+    }, 0);
+  });
+}

--- a/src/server/views/macros/elements/button.njk
+++ b/src/server/views/macros/elements/button.njk
@@ -1,8 +1,8 @@
-{% macro button(text='', url=false, start=false, disabled=false, secondary=false) %}
+{% macro button(text='', url=false, start=false, disabled=false, secondary=false, id=undefined) %}
   {% set disabledCode = 'disabled="disabled" aria-disabled="true"' %}
   {% if url %}
-    <a class="button {{ 'button-start' if start }}" href="{{ urlroot }}{{ url }}" role="button">{{ text }}</a>
+    <a class="button {{ 'button-start' if start }}" href="{{ urlroot }}{{ url }}" role="button" id={{id}}>{{ text }}</a>
   {% else %}
-    <input class="button {{ 'secondary-button' if secondary }}" type="submit" value="{{ text }}" {{ disabledCode if disabled }}>
+    <input class="button {{ 'secondary-button' if secondary }}" type="submit" value="{{ text }}" id={{id}} {{ disabledCode if disabled }}>
   {% endif %}
 {% endmacro %}

--- a/src/server/views/payment/cash.njk
+++ b/src/server/views/payment/cash.njk
@@ -59,8 +59,9 @@
 
           {{ components.heading(text="Payment details ", tag="h3", size="medium") }}
          <p>{{ components.field(id="slipNumber", type="number", label="Paying in slip number", required=true) }}</p>
-          {{ components.button(text="Confirm cash payment", type="submit") }}
+          {{ components.button(text="Confirm cash payment", type="submit", id="confirm-payment-button") }}
         {%- endcall %}
     {%- endcall %}
   {%- endcall %}
+  <script src="{{ assets }}/javascripts/disable-button-on-click.js" type="text/javascript"></script>
 {% endblock %}

--- a/src/server/views/payment/cheque.njk
+++ b/src/server/views/payment/cheque.njk
@@ -63,8 +63,9 @@
           <p>{{ components.field(id="chequeNumber", type="number", label= "Cheque number", required=true) }}</p>
           <p>{{ components.field(id="nameOnCheque", label="Name on cheque", required=true) }}</p>
           <p>{{ components.field(id="slipNumber", type="number", label="Paying in slip number", required=true) }}</p>
-          {{ components.button(text="Confirm payment", type="submit") }}
+          {{ components.button(text="Confirm payment", type="submit", id="confirm-payment-button") }}
         {%- endcall %}
     {%- endcall %}
   {%- endcall %}
+  <script src="{{ assets }}/javascripts/disable-button-on-click.js" type="text/javascript"></script>
 {% endblock %}

--- a/src/server/views/payment/groupCash.njk
+++ b/src/server/views/payment/groupCash.njk
@@ -65,8 +65,9 @@
           <p>
             {{ components.field(id="slipNumber", type="number", label="Paying in slip number", required=true) }}
           </p>
-          {{ components.button(text="Confirm cash payment", type="submit") }}
+          {{ components.button(text="Confirm cash payment", type="submit", id="confirm-payment-button") }}
         {%- endcall %}
     {%- endcall %}
   {%- endcall %}
+  <script src="{{ assets }}/javascripts/disable-button-on-click.js" type="text/javascript"></script>
 {% endblock %}

--- a/src/server/views/payment/groupCheque.njk
+++ b/src/server/views/payment/groupCheque.njk
@@ -71,8 +71,9 @@
           <p>{{ components.field(id="chequeNumber", type="number", label= "Cheque number", required=true) }}</p>
           <p>{{ components.field(id="nameOnCheque", label="Name on cheque", required=true) }}</p>
           <p>{{ components.field(id="slipNumber", type="number", label="Paying in slip number", required=true) }}</p>
-          {{ components.button(text="Confirm payment", type="submit") }}
+          {{ components.button(text="Confirm payment", type="submit", id="confirm-payment-button") }}
         {%- endcall %}
     {%- endcall %}
   {%- endcall %}
+  <script src="{{ assets }}/javascripts/disable-button-on-click.js" type="text/javascript"></script>
 {% endblock %}

--- a/src/server/views/payment/groupPostalOrder.njk
+++ b/src/server/views/payment/groupPostalOrder.njk
@@ -69,8 +69,9 @@
           {{ components.heading(text="Payment details ", tag="h3", size="medium") }}
           <p>{{ components.field(id="postalOrderNumber", type="number", label= "Postal order number", required=true) }}</p>
           <p>{{ components.field(id="slipNumber", type="number", label="Paying in slip number", required=true) }}</p>
-          {{ components.button(text="Confirm payment", type="submit") }}
+          {{ components.button(text="Confirm payment", type="submit", id="confirm-payment-button") }}
         {%- endcall %}
     {%- endcall %}
   {%- endcall %}
+  <script src="{{ assets }}/javascripts/disable-button-on-click.js" type="text/javascript"></script>
 {% endblock %}

--- a/src/server/views/payment/postal.njk
+++ b/src/server/views/payment/postal.njk
@@ -61,8 +61,9 @@
           {{ components.heading(text="Payment details ", tag="h3", size="medium") }}
           <p>{{ components.field(id="postalOrderNumber", type="number", label= "Postal order number", required=true) }}</p>
           <p>{{ components.field(id="slipNumber", type="number", label="Paying in slip number", required=true) }}</p>
-          {{ components.button(text="Confirm payment", type="submit") }}
+          {{ components.button(text="Confirm payment", type="submit", id="confirm-payment-button") }}
         {%- endcall %}
     {%- endcall %}
   {%- endcall %}
+  <script src="{{ assets }}/javascripts/disable-button-on-click.js" type="text/javascript"></script>
 {% endblock %}


### PR DESCRIPTION
Currently, if pay is double clicked, the payment is recorded in CPMS twice. Disable the pay button when clicked.