### PR TITLE
RSP-1747: Block cancellation of penalties with recent payment attempts

### DIFF
--- a/src/server/config.js
+++ b/src/server/config.js
@@ -17,6 +17,7 @@ const configMetadata = {
   iamClientSecret: 'IAM_CLIENT_SECRET',
   identityProvider: 'IDENTITY_PROVIDER',
   nodeEnv: 'NODE_ENV',
+  orphanedPaymentCheckingTime: 'ORPHANED_PAYMENT_CHECKING_TIME',
   paymentServiceUrl: 'PAYMENT_SERVICE_URL',
   penaltyServiceUrl: 'PENALTY_SERVICE_URL',
   port: 'PORT',
@@ -114,6 +115,10 @@ function isDevelopment() {
   return env() === 'development';
 }
 
+function orphanedPaymentCheckingTime() {
+  return configuration[configMetadata.orphanedPaymentCheckingTime];
+}
+
 function paymentServiceUrl() {
   return configuration[configMetadata.paymentServiceUrl];
 }
@@ -165,6 +170,7 @@ const config = {
   iamClientSecret,
   identityProvider,
   isDevelopment,
+  orphanedPaymentCheckingTime,
   paymentServiceUrl,
   penaltyServiceUrl,
   port,

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -116,7 +116,7 @@ function isDevelopment() {
 }
 
 function orphanedPaymentCheckingTime() {
-  return configuration[configMetadata.orphanedPaymentCheckingTime];
+  return Number(configuration[configMetadata.orphanedPaymentCheckingTime]);
 }
 
 function paymentServiceUrl() {

--- a/src/server/controllers/paymentCode.controller.js
+++ b/src/server/controllers/paymentCode.controller.js
@@ -6,7 +6,6 @@ import config from './../config';
 import { logError, logInfo } from './../utils/logger';
 import PenaltyGroupService from '../services/penaltyGroup.service';
 import tryAddCancellationFlagToViewData from '../utils/tryAddCancellationFlagToViewData';
-import { recentPayment } from '../utils/recentPayment';
 
 const penaltyService = new PenaltyService(config.penaltyServiceUrl());
 const penaltyGroupService = new PenaltyGroupService(config.penaltyServiceUrl());
@@ -60,7 +59,6 @@ export const getPenaltyDetails = [
     const finalViewData = {
       ...tryAddCancellationFlagToViewData(req, viewData),
       ...req.session,
-      isCancellable: viewData.status == 'UNPAID' && viewData.enabled === true && !recentPayment(viewData.paymentStartTime),
     };
     res.render(view, finalViewData);
   },

--- a/src/server/controllers/paymentCode.controller.js
+++ b/src/server/controllers/paymentCode.controller.js
@@ -6,6 +6,7 @@ import config from './../config';
 import { logError, logInfo } from './../utils/logger';
 import PenaltyGroupService from '../services/penaltyGroup.service';
 import tryAddCancellationFlagToViewData from '../utils/tryAddCancellationFlagToViewData';
+import { recentPayment } from '../utils/recentPayment';
 
 const penaltyService = new PenaltyService(config.penaltyServiceUrl());
 const penaltyGroupService = new PenaltyGroupService(config.penaltyServiceUrl());
@@ -59,6 +60,7 @@ export const getPenaltyDetails = [
     const finalViewData = {
       ...tryAddCancellationFlagToViewData(req, viewData),
       ...req.session,
+      isCancellable: viewData.status == 'UNPAID' && viewData.enabled === true && !recentPayment(viewData.paymentStartTime),
     };
     res.render(view, finalViewData);
   },

--- a/src/server/controllers/penalty.controller.js
+++ b/src/server/controllers/penalty.controller.js
@@ -5,6 +5,7 @@ import PenaltyService from './../services/penalty.service';
 import config from '../config';
 import tryAddCancellationFlagToViewData from '../utils/tryAddCancellationFlagToViewData';
 import { logInfo, logError } from '../utils/logger';
+import { recentPayment } from '../utils/recentPayment';
 
 const penaltyService = new PenaltyService(config.penaltyServiceUrl());
 
@@ -25,7 +26,11 @@ export const getPenaltyDetails = [
 
       penaltyService.getById(penaltyId).then((penaltyDetails) => {
         const viewData = tryAddCancellationFlagToViewData(req, penaltyDetails);
-        res.render('penalty/penaltyDetails', { ...viewData, ...req.session });
+        res.render('penalty/penaltyDetails', {
+          ...viewData,
+          ...req.session,
+          isCancellable: penaltyDetails.status == 'UNPAID' && penaltyDetails.enabled === true && !recentPayment(penaltyDetails.paymentStartTime)
+        });
       }).catch(() => {
         res.redirect(`../?invalid${penaltyType}`);
       });

--- a/src/server/controllers/penalty.controller.js
+++ b/src/server/controllers/penalty.controller.js
@@ -29,7 +29,7 @@ export const getPenaltyDetails = [
         res.render('penalty/penaltyDetails', {
           ...viewData,
           ...req.session,
-          isCancellable: penaltyDetails.status == 'UNPAID' && penaltyDetails.enabled === true && !recentPayment(penaltyDetails.paymentStartTime)
+          isCancellable: penaltyDetails.status === 'UNPAID' && penaltyDetails.enabled === true && !recentPayment(penaltyDetails.paymentStartTime),
         });
       }).catch(() => {
         res.redirect(`../?invalid${penaltyType}`);

--- a/src/server/controllers/penalty.controller.js
+++ b/src/server/controllers/penalty.controller.js
@@ -29,7 +29,10 @@ export const getPenaltyDetails = [
         res.render('penalty/penaltyDetails', {
           ...viewData,
           ...req.session,
-          isCancellable: penaltyDetails.status === 'UNPAID' && penaltyDetails.enabled === true && !recentPayment(penaltyDetails.paymentStartTime),
+          isCancellable:
+            penaltyDetails.status === 'UNPAID' &&
+            penaltyDetails.enabled === true &&
+            !recentPayment(penaltyDetails.paymentStartTime),
         });
       }).catch(() => {
         res.redirect(`../?invalid${penaltyType}`);

--- a/src/server/services/penalty.service.js
+++ b/src/server/services/penalty.service.js
@@ -51,6 +51,7 @@ export default class PenaltyService {
       paymentCodeIssueDateTime: rawPenalty.paymentCodeDateTime ?
         moment.unix(rawPenalty.paymentCodeDateTime).format(MOMENT_DATE_TIME_FORMAT)
         : undefined,
+      paymentStartTime: rawPenalty.paymentStartTime,
     };
     return penaltyDetails;
   }

--- a/src/server/services/penaltyGroup.service.js
+++ b/src/server/services/penaltyGroup.service.js
@@ -4,8 +4,7 @@ import { find, isEmpty, uniq } from 'lodash';
 import PenaltyService from './penalty.service';
 import SignedHttpClient from '../utils/httpclient';
 import { MOMENT_DATE_TIME_FORMAT } from '../utils/dateTimeFormat';
-
-const ORPHANED_PAYMENT_CHECKING_TIME = 3.6e6;
+import { recentPayment } from '../utils/recentPayment';
 
 export default class PenaltyGroupService {
   constructor(serviceUrl) {
@@ -100,13 +99,5 @@ export default class PenaltyGroupService {
 
   cancel(paymentCode) {
     return this.httpClient.delete(`penaltyGroup/${paymentCode}`, undefined, 'CancelPenaltyGroup');
-  }
-
-  recentPayment(time) {
-    if (time) {
-      const ageMilliseconds = moment.duration(moment(moment.now()).diff(moment(time))).asMilliseconds();
-      return ageMilliseconds < ORPHANED_PAYMENT_CHECKING_TIME;
-    }
-    return false;
   }
 }

--- a/src/server/services/penaltyGroup.service.js
+++ b/src/server/services/penaltyGroup.service.js
@@ -36,7 +36,11 @@ export default class PenaltyGroupService {
       nextPayment,
     } = PenaltyGroupService.parsePayments(Payments);
     // If a recent payment attempt was made, block cancellation
-    const recentPendingPayment = recentPayment(fpnPaymentStartTime) || recentPayment(imPaymentStartTime) || recentPayment(cdnPaymentStartTime);
+    const recentPendingPayment =
+      recentPayment(fpnPaymentStartTime) ||
+      recentPayment(imPaymentStartTime) ||
+      recentPayment(cdnPaymentStartTime);
+
     return {
       isPenaltyGroup: true,
       isCancellable: splitAmounts.some(a => a.status === 'UNPAID') && Enabled !== false && !recentPendingPayment,

--- a/src/server/utils/recentPayment.js
+++ b/src/server/utils/recentPayment.js
@@ -4,7 +4,9 @@ import config from '../config';
 
 export const recentPayment = (timeSeconds) => {
   if (timeSeconds) {
-    const age = moment.duration(moment(moment.now()).diff(moment(timeSeconds * 1000))).asMilliseconds();
+    const now = moment(moment.now());
+    const paymentTime = moment(timeSeconds * 1000);
+    const age = moment.duration(now.diff(paymentTime)).asMilliseconds();
     return age < config.orphanedPaymentCheckingTime();
   }
   return false;

--- a/src/server/utils/recentPayment.js
+++ b/src/server/utils/recentPayment.js
@@ -1,12 +1,11 @@
 import moment from 'moment';
+import config from '../config';
 
 
-const ORPHANED_PAYMENT_CHECKING_TIME = 3.6e6;
-
-export const recentPayment = (time) => {
-  if (time) {
-    const age = moment.duration(moment(moment.now()).diff(moment(time))).asMilliseconds();
-    return age < ORPHANED_PAYMENT_CHECKING_TIME;
+export const recentPayment = (timeSeconds) => {
+  if (timeSeconds) {
+    const age = moment.duration(moment(moment.now()).diff(moment(timeSeconds * 1000))).asMilliseconds();
+    return age < config.orphanedPaymentCheckingTime();
   }
   return false;
 };

--- a/src/server/utils/recentPayment.js
+++ b/src/server/utils/recentPayment.js
@@ -5,8 +5,8 @@ const ORPHANED_PAYMENT_CHECKING_TIME = 3.6e6;
 
 export const recentPayment = (time) => {
   if (time) {
-    const ageMilliseconds = moment.duration(moment(moment.now()).diff(moment(time))).asMilliseconds();
-    return ageMilliseconds < ORPHANED_PAYMENT_CHECKING_TIME;
+    const age = moment.duration(moment(moment.now()).diff(moment(time))).asMilliseconds();
+    return age < ORPHANED_PAYMENT_CHECKING_TIME;
   }
   return false;
-}
+};

--- a/src/server/utils/recentPayment.js
+++ b/src/server/utils/recentPayment.js
@@ -1,0 +1,12 @@
+import moment from 'moment';
+
+
+const ORPHANED_PAYMENT_CHECKING_TIME = 3.6e6;
+
+export const recentPayment = (time) => {
+  if (time) {
+    const ageMilliseconds = moment.duration(moment(moment.now()).diff(moment(time))).asMilliseconds();
+    return ageMilliseconds < ORPHANED_PAYMENT_CHECKING_TIME;
+  }
+  return false;
+}

--- a/src/server/views/penalty/penaltyDetails.njk
+++ b/src/server/views/penalty/penaltyDetails.njk
@@ -123,7 +123,7 @@
         {% endif %}
     {%- endcall %}
 
-    {% if status == 'UNPAID' and enabled == true %}
+    {% if isCancellable %}
       {% call components.columnOneThird() %}
       <aside class="govuk-related-items" role="complementary">
         {{ components.heading(text='Additional actions', tag='h3', size='medium') }}


### PR DESCRIPTION
Block cancellation of penalties with recent payment attempts to stop internal portal users from cancelling payment codes with orphaned payments. Blocking cancellation for 1 hour from card payments being started.