### PR TITLE
feat: Version pin to v1 of DVSA GitHub actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,15 +8,15 @@ on:
 jobs:
 
   lint:
-    uses: dvsa/.github/.github/workflows/nodejs-lint.yaml@main
+    uses: dvsa/.github/.github/workflows/nodejs-lint.yaml@v1.0.0
 
   test:
-    uses: dvsa/.github/.github/workflows/nodejs-test.yaml@main
+    uses: dvsa/.github/.github/workflows/nodejs-test.yaml@v1.0.0
 
   security:
-    uses: dvsa/.github/.github/workflows/nodejs-security.yaml@main
+    uses: dvsa/.github/.github/workflows/nodejs-security.yaml@v1.0.0
     with:
-      args: '--dev --all-projects --policy-path=/github/workspace/.snyk'
+      args: '--all-projects'
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
@@ -39,7 +39,7 @@ jobs:
 
   build:
     if: startsWith( github.ref, 'refs/heads/feature/') || startsWith( github.ref, 'refs/heads/fix/') || ${{ github.ref_name == 'main' }}
-    uses: dvsa/.github/.github/workflows/nodejs-build.yaml@main
+    uses: dvsa/.github/.github/workflows/nodejs-build.yaml@v1.0.0
     needs: [ build-names ]
     with:
       upload-artifact: true
@@ -50,7 +50,7 @@ jobs:
 
   upload-s3:
     if: startsWith( github.ref, 'refs/heads/feature/') || startsWith( github.ref, 'refs/heads/fix/') || ${{ github.ref_name == 'main' }}
-    uses: dvsa/.github/.github/workflows/upload-to-s3.yaml@main
+    uses: dvsa/.github/.github/workflows/upload-to-s3.yaml@v1.0.0
     needs: [ build-names, build ]
     with:
       environment: nonprod

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ build/
 
 .vscode/*
 !.vscode/launch.json
+
+# Mac files
+.DS_Store


### PR DESCRIPTION
## Description

- New version of DVSA workflows will be available soon
- To avoid breaking current CI steps, pin to v1
- Add Mac file .DS_Store to .gitignore

Related issue: n/a

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
