### PR TITLE
fix: Fix for delete failing and not displaying error

### DIFF
--- a/src/server/controllers/payment.controller.js
+++ b/src/server/controllers/payment.controller.js
@@ -475,6 +475,7 @@ export const reversePayment = async (req, res) => {
   }
 
   try {
+    logInfo('ReversePayment', { penaltyId, paymentCode });
     await paymentService.reversePayment(penaltyId);
     return res.redirect(`${config.urlRoot()}/payment-code/${paymentCode}`);
   } catch (error) {
@@ -520,7 +521,7 @@ export const reverseGroupPayment = async (req, res) => {
       ...logMesssage,
       error: cpmsError.message,
     });
-    return res.redirect(`${config.urlRoot()}/payment-code/${paymentCode}`);
+    return res.redirect(`${config.urlRoot()}/payment-code/${paymentCode}?reverse=failed`);
   }
 
   try {
@@ -532,7 +533,7 @@ export const reverseGroupPayment = async (req, res) => {
       ...logMesssage,
       error: error.message,
     });
-    return res.redirect(`${config.urlRoot()}/payment-code/${paymentCode}`);
+    return res.redirect(`${config.urlRoot()}/payment-code/${paymentCode}?reverse=failed`);
   }
 };
 

--- a/src/server/controllers/paymentCode.controller.js
+++ b/src/server/controllers/paymentCode.controller.js
@@ -85,8 +85,10 @@ export const cancelPaymentCode = async (req, res) => {
   });
   try {
     await penaltyGroupService.cancel(paymentCode);
+    logInfo('cancelPaymentCodeSuccess', { paymentCode });
     res.redirect(`${config.urlRoot()}/payment-code/${paymentCode}`);
   } catch (error) {
+    logError('cancelPaymentCodeError', { paymentCode, error });
     res.redirect(`${config.urlRoot()}/payment-code/${paymentCode}?cancellation=failed`);
   }
 };

--- a/src/server/controllers/penalty.controller.js
+++ b/src/server/controllers/penalty.controller.js
@@ -47,16 +47,15 @@ export const cancelPenalty = async (req, res) => {
     userEmail: req.session.rsp_user.email,
     penaltyId,
   };
-  logInfo('CancelPenalty', logMessage);
   try {
     await penaltyService.cancel(penaltyId);
-    res.redirect(`${config.urlRoot()}/penalty/${penaltyId}`);
     logInfo('CancelPenaltySuccess', logMessage);
+    res.redirect(`${config.urlRoot()}/penalty/${penaltyId}`);
   } catch (error) {
-    res.redirect(`${config.urlRoot()}/penalty/${penaltyId}?cancellation=failed`);
     logError('CancelPenaltyError', {
       ...logMessage,
       error: error.message,
     });
+    res.redirect(`${config.urlRoot()}/penalty/${penaltyId}?cancellation=failed`);
   }
 };

--- a/src/server/services/payment.service.js
+++ b/src/server/services/payment.service.js
@@ -1,5 +1,5 @@
 import SignedHttpClient from '../utils/httpclient';
-import { ServiceName } from '../utils/logger';
+import { logInfo, ServiceName } from '../utils/logger';
 
 export default class PaymentService {
   constructor(serviceUrl) {
@@ -19,10 +19,11 @@ export default class PaymentService {
   }
 
   reverseGroupPayment(paymentId, penaltyType) {
-    return this.httpClient.delete(`groupPayments/${paymentId}/${penaltyType}`, 'ReverseGroupPayment');
+    return this.httpClient.delete(`groupPayments/${paymentId}/${penaltyType}`, {}, 'ReverseGroupPayment');
   }
 
   reversePayment(paymentId) {
-    return this.httpClient.delete(`payments/${paymentId}`, 'ReversePayment');
+    logInfo('PaymentServiceReversePayment', { paymentId });
+    return this.httpClient.delete(`payments/${paymentId}`, {}, 'ReversePayment');
   }
 }

--- a/src/server/utils/formatUserRole.js
+++ b/src/server/utils/formatUserRole.js
@@ -1,5 +1,5 @@
 export default (rawRole) => {
-  if(!rawRole){
+  if (!rawRole) {
     return null;
   }
   const isSingleRole = rawRole.indexOf('[') === -1;

--- a/src/server/utils/httpclient.js
+++ b/src/server/utils/httpclient.js
@@ -4,9 +4,9 @@ import aws4 from 'aws4';
 import { isNumber } from 'lodash';
 import URL from 'url-parse';
 import { isObject } from 'util';
+import { logAxiosError } from './logger';
 
 import config from '../config';
-import { logAxiosError } from './logger';
 
 export const createUnsignedHttpClient = (baseURL, headers = { Authorization: 'allow' }) => axios.create({
   baseURL,
@@ -99,7 +99,7 @@ export default class SignedHttpClient {
       });
     }
     const url = new URL(path, this.baseUrlOb.href);
-    return axios.delete(url, request).catch((err) => {
+    return axios.delete(url.href, request).catch((err) => {
       logAxiosError(logName, this.serviceName, err, body);
       throw err;
     });

--- a/src/server/utils/tryAddCancellationFlagToViewData.js
+++ b/src/server/utils/tryAddCancellationFlagToViewData.js
@@ -4,5 +4,8 @@ export default (req, viewData) => {
   if (has(req.query, 'cancellation') && req.query.cancellation === 'failed') {
     return { ...viewData, cancellationFailed: true };
   }
+  if (has(req.query, 'reverse') && req.query.reverse === 'failed') {
+    return { ...viewData, reverseFailed: true };
+  }
   return viewData;
 };

--- a/src/server/views/penalty/penaltyDetails.njk
+++ b/src/server/views/penalty/penaltyDetails.njk
@@ -33,6 +33,14 @@
         </div>
       {% endif %}
 
+      {% if reverseFailed %}
+        <div class="error-summary" role="alert" aria-labelledby="error-summary-heading-reverse-failed" tabindex="-1">
+          <h2 class="heading-medium error-summary-heading">
+            The reverse payment failed.
+          </h2>
+        </div>
+      {% endif %}
+
       {% if enabled == false %}
         <p>
           {{ components.notice(text='This payment code has been cancelled') }} 

--- a/src/server/views/penalty/penaltyGroupSummary.njk
+++ b/src/server/views/penalty/penaltyGroupSummary.njk
@@ -29,6 +29,14 @@
         </div>
       {% endif %}
 
+      {% if reverseFailed %}
+        <div class="error-summary" role="alert" aria-labelledby="error-summary-heading-reverse-failed" tabindex="-1">
+          <h2 class="heading-medium error-summary-heading">
+            The reverse payment failed.
+          </h2>
+        </div>
+      {% endif %}
+
       {% if penaltyGroupDetails.enabled == false %}
         <p>
           {{ components.notice(text='This payment code has been cancelled') }} 


### PR DESCRIPTION
## Description

- Fix missing param which caused error on deleting payments and penalties
- If the reverse card payment fails, the page reloads but no error message is shown
- Added new failed error type and returned to view penalty page for the user
- Fix for delete http client using `url` object instead of `href` string for request to payment service lambdas

Related issue: [RSP-2074](https://dvsa.atlassian.net/browse/RSP-2074)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
