### PR TITLE
fix: Add fix for redirecting on capita page

### DIFF
--- a/src/server/app.js
+++ b/src/server/app.js
@@ -61,6 +61,7 @@ export default async () => {
   app.use(helmet.contentSecurityPolicy({
     directives: {
       defaultSrc: ["'self'", assetsUrl],
+      formAction: ['*'],
       scriptSrc: [
         assetsUrl,
         'https://www.googletagmanager.com/',


### PR DESCRIPTION
## Description

- On Chrome, clicking the payment button which should direct users to the Capita payment page was redirecting back to the penalty page
- This was due to the Helmet upgrade which now default to: "form-action 'self'" whereas previously it allowed any.
- To fix, set `form-action: '*'` which allows any redirect and now allows redirecting to Capita payment page

Related issue: [RSP-2076](https://dvsa.atlassian.net/browse/RSP-2076)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
