### PR TITLE
feat: Add new 28 day validation and CPMS error catching

### DIFF
--- a/src/server/utils/logger.js
+++ b/src/server/utils/logger.js
@@ -28,7 +28,7 @@ export function logDebug(logName, message) {
   }, null, 2));
 }
 
-function errorMessageFromAxiosError(error) {
+export function errorMessageFromAxiosError(error) {
   if (error.response) {
     // The request was made and the server responded with a status code
     // that falls out of the range of 2xx

--- a/src/server/utils/validDateRange.js
+++ b/src/server/utils/validDateRange.js
@@ -1,17 +1,39 @@
 import moment from 'moment';
+import { errorTypes } from '../validation/reports';
 
 /**
  * Validate the submitted dates are no later than today and the endDate
  * is not earlier than the start date.
+ * Additionally, CPMS currently does not allow reports to be
+ * generated for greater than 28 days.
  * @param {string} startDateText End date in the format yyyy-mm-dd
  * @param {string} endDateText Start date in the format yyyy-mm-dd
  */
+
 export default function validDateRange(startDateText, endDateText) {
   const dateToday = moment().startOf('day');
   const startDate = moment(startDateText);
+  if (!startDate.isValid()) {
+    return { isValid: false, type: errorTypes.invalidDateEntry };
+  }
   const endDate = moment(endDateText);
+  if (!endDate.isValid()) {
+    return { isValid: false, type: errorTypes.invalidDateEntry };
+  }
   const endAfterStart = endDate.isSameOrAfter(startDate);
-  const dateNotInFuture = dateToday.isSameOrAfter(endDate);
+  if (!endAfterStart) {
+    return { isValid: false, type: errorTypes.startAfterEnd };
+  }
 
-  return dateNotInFuture && endAfterStart;
+  const dateNotInFuture = dateToday.isSameOrAfter(endDate);
+  if (!dateNotInFuture) {
+    return { isValid: false, type: errorTypes.dateInFuture };
+  }
+
+  const over28Days = endDate.diff(startDate, 'days') > 28;
+  if (over28Days) {
+    return { isValid: false, type: errorTypes.over28Days };
+  }
+
+  return { isValid: true };
 }

--- a/src/server/validation/reports.js
+++ b/src/server/validation/reports.js
@@ -1,0 +1,15 @@
+export const errorTypes = {
+  startAfterEnd: 'startAfterEnd',
+  dateInFuture: 'dateInFuture',
+  over28Days: 'over28Days',
+  cpmsError: 'cpmsError',
+  invalidDateEntry: 'invalidDateEntry',
+};
+
+export const errorMessages = {
+  startAfterEnd: 'The from date cannot be after the to date.',
+  dateInFuture: 'Dates cannot be in the future.',
+  over28Days: 'Reports over 28 days cannot be generated.',
+  cpmsError: 'There was a server error. Please try again later.',
+  invalidDateEntry: 'One or more dates entered was invalid.',
+};

--- a/src/server/views/reports/generateReport.njk
+++ b/src/server/views/reports/generateReport.njk
@@ -17,7 +17,9 @@
             <h2 class="heading-medium error-summary-heading" id="error-summary-generate-report">
               There was a problem
             </h2>
-            The date range you entered was invalid.
+            <p>
+              {{ dateValidationMessage }}
+            </p>
           </div>
         {% endif %}
         {% call components.form(action='', method='POST') %}

--- a/test/utils/validDateRange.spec.js
+++ b/test/utils/validDateRange.spec.js
@@ -1,25 +1,45 @@
 import { expect } from 'chai';
+import sinon from 'sinon';
 import validDateRange from '../../src/server/utils/validDateRange';
+import { errorTypes } from '../../src/server/validation/reports';
 
 describe('validDateRange', () => {
   context('start date is after end date', () => {
     it('fails the validation', () => {
-      const isValid = validDateRange('2018-01-02', '2018-01-01');
-      expect(isValid).to.be.false;
+      const validation = validDateRange('2018-01-02', '2018-01-01');
+      expect(validation.isValid).to.be.false;
+      expect(validation.type).to.equal(errorTypes.startAfterEnd);
     });
   });
 
   context('start date is after today', () => {
     it('fails the validation', () => {
-      const isValid = validDateRange('5000-01-02', '5000-01-03');
-      expect(isValid).to.be.false;
+      const validation = validDateRange('5000-01-02', '5000-01-03');
+      expect(validation.isValid).to.be.false;
+      expect(validation.type).to.equal(errorTypes.dateInFuture);
     });
   });
 
   context('date range is valid', () => {
     it('passes the validation', () => {
-      const isValid = validDateRange('2018-01-01', '2018-01-02');
-      expect(isValid).to.be.true;
+      const validation = validDateRange('2018-01-01', '2018-01-02');
+      expect(validation.isValid).to.be.true;
+    });
+  });
+
+  context('start date is over 28 days', () => {
+    it('fails the validation', () => {
+      const validation = validDateRange('2022-01-01', '2022-01-30');
+      expect(validation.isValid).to.be.false;
+      expect(validation.type).to.equal(errorTypes.over28Days);
+    });
+  });
+
+  context('start date is nonsense', () => {
+    it('fails the validation', () => {
+      const validation = validDateRange('not a date', '2022-01-03');
+      expect(validation.isValid).to.be.false;
+      expect(validation.type).to.equal(errorTypes.invalidDateEntry);
     });
   });
 });


### PR DESCRIPTION
## Description
- Prevent user from generating reports with more than 28 days of data
- Added error catching for when CPMS rejects requests
- Added type logging for different types of validation failures
- Error message displayed to user is different based on failure
- Added reports.js to validation to store both types and messages
- Added new unit tests to check new 28 day validation, incorrect dates entered

Related issue: [RSP-2123](https://dvsa.atlassian.net/browse/RSP-2123?atlOrigin=eyJpIjoiM2IzNTFlODBiMzRjNGRiMGI4ZjU2NzJhMjRmMDc1ODMiLCJwIjoiaiJ9)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
