### PR TITLE
fix: Fix for local building issues

### DIFF
--- a/dvsa-frontend-webpack/webpack.config.common.babel.js
+++ b/dvsa-frontend-webpack/webpack.config.common.babel.js
@@ -24,13 +24,12 @@ module.exports = {
                 targets: {
                   browsers: [
                     'last 3 versions',
-                    'ie >= 8',
                     'last 3 iOS major versions',
                   ],
                 },
                 debug: false,
                 useBuiltIns: 'entry',
-                corejs: '2',
+                corejs: '3',
               }],
             ],
             plugins: [

--- a/dvsa-frontend-webpack/webpack.config.development.babel.js
+++ b/dvsa-frontend-webpack/webpack.config.development.babel.js
@@ -6,14 +6,10 @@ import merge from 'webpack-merge';
 
 module.exports = merge(common, {
   mode: 'development',
+  devtool: 'inline-source-map',
   output: {
     filename: '[name].bundle.js',
     path: path.resolve('build', 'public', 'javascripts'),
   },
   watch: false,
-  plugins: [
-    // More info:
-    // https://webpack.js.org/plugins/source-map-dev-tool-plugin/
-    new webpack.SourceMapDevToolPlugin(),
-  ],
 });

--- a/dvsa-frontend-webpack/webpack.config.production.babel.js
+++ b/dvsa-frontend-webpack/webpack.config.production.babel.js
@@ -10,7 +10,4 @@ module.exports = merge(common, {
     filename: '[name].bundle.js',
     path: path.resolve('dist', 'public', 'javascripts'),
   },
-  plugins: [
-    new webpack.optimize.UglifyJsPlugin()
-  ],
 });

--- a/package.json
+++ b/package.json
@@ -48,8 +48,6 @@
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-chai-friendly": "^0.7.2",
     "eslint-webpack-plugin": "^3.2.0",
-    "eslint-config-airbnb-base": "^15.0.0",
-    "eslint-plugin-chai-friendly": "^0.7.2",
     "nodemon": "^2.0.19",
     "gulp": "4.0",
     "gulp-autoprefixer": "^8.0.0",


### PR DESCRIPTION
## Description

- Webpack was building in dev mode using eval
- CSP was blocking use of eval, which was breaking built pages
- To fix, updated webpack development build, remove old plugins, use webpack in-built source maps
- Removed duplicate packages from package.json

Related issue: n/a

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
