### PR TITLE
feat: Single penalty reversal failure error messages

### DIFF
--- a/src/server/controllers/payment.controller.js
+++ b/src/server/controllers/payment.controller.js
@@ -486,7 +486,7 @@ export const reversePayment = async (req, res) => {
       ...logMessage,
       error: cpmsError.message,
     });
-    return res.redirect(`${config.urlRoot()}/payment-code/${paymentCode}`);
+    return res.redirect(`${config.urlRoot()}/payment-code/${paymentCode}?reverse=failed`);
   }
 
   try {
@@ -494,7 +494,7 @@ export const reversePayment = async (req, res) => {
     await paymentService.reversePayment(penaltyId);
     return res.redirect(`${config.urlRoot()}/payment-code/${paymentCode}`);
   } catch (error) {
-    return res.redirect(`${config.urlRoot()}/payment-code/${paymentCode}`);
+    return res.redirect(`${config.urlRoot()}/payment-code/${paymentCode}?reverse=failed`);
   }
 };
 

--- a/src/server/views/penalty/penaltyDetails.njk
+++ b/src/server/views/penalty/penaltyDetails.njk
@@ -38,6 +38,7 @@
           <h2 class="heading-medium error-summary-heading">
             The reverse payment failed.
           </h2>
+          <p>Please note: if payment has been made within the last 24 hours, payment reversal will fail.</p>
         </div>
       {% endif %}
 

--- a/src/server/views/penalty/penaltyGroupSummary.njk
+++ b/src/server/views/penalty/penaltyGroupSummary.njk
@@ -34,6 +34,7 @@
           <h2 class="heading-medium error-summary-heading">
             The reverse payment failed.
           </h2>
+          <p>Please note: if payment has been made within the last 24 hours, payment reversal will fail.</p>
         </div>
       {% endif %}
 


### PR DESCRIPTION
## Description:
- Fixed an issue where no error message was displayed when an attempt to reverse a penalty on a single penalty had failed.
- Added context to error message, explaining it is not possible to reverse a payment within 24 hours of receipt - but not explicity stating this is why the payment failed.

Related issue: [RSP-2124](https://dvsa.atlassian.net/browse/RSP-2124?atlOrigin=eyJpIjoiOTBlMDFiMWFkYTNjNDBjMDlhOGY4MmE3YWMwZDE3ZGEiLCJwIjoiaiJ9)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
