### PR TITLE
feat: added functionality for cancelling single payments, includes tests

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -17,3 +17,7 @@ ignore:
     - '*' :
       reason: 'Known cognito-express vulnerability'
       expires: '2023-01-31T09:00:00.000Z'
+  SNYK-JS-DEBUG-3227433:
+    - '*' :
+      reason: 'Known debug vulnerability'
+      expires: '2023-01-31T09:00:00.000Z'

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -117,7 +117,7 @@ function isDevelopment() {
 }
 
 function orphanedPaymentCheckingTime() {
-  return Number(configuration[configMetadata.orphanedPaymentCheckingTime]);
+  return Number(configuration[configMetadata.orphanedPaymentCheckingTime] || 1800000);
 }
 
 function paymentServiceUrl() {

--- a/src/server/services/penalty.service.js
+++ b/src/server/services/penalty.service.js
@@ -6,6 +6,7 @@ import config from '../config';
 import SignedHttpClient from '../utils/httpclient';
 import { MOMENT_DATE_FORMAT, MOMENT_DATE_TIME_FORMAT } from '../utils/dateTimeFormat';
 import { logDebug, ServiceName } from '../utils/logger';
+import { isCancellable } from '../utils/isCancellable';
 
 export default class PenaltyService {
   constructor(serviceUrl) {
@@ -54,6 +55,7 @@ export default class PenaltyService {
         : undefined,
       isPaymentOverdue: isPaymentOverdue(rawPenalty.paymentCodeDateTime, config.paymentLimitDays()),
       paymentStartTime: rawPenalty.paymentStartTime,
+      isCancellable: isCancellable(rawPenalty.paymentStatus, data.Enabled, rawPenalty.paymentStartTime),
     };
     return penaltyDetails;
   }
@@ -64,7 +66,6 @@ export default class PenaltyService {
       paymentCode,
     });
     const response = await this.httpClient.get(`documents/tokens/${paymentCode}`, 'GetByPaymentCode');
-
     if (isEmpty(response.data)) {
       throw new Error('Payment code not found');
     }

--- a/src/server/utils/isCancellable.js
+++ b/src/server/utils/isCancellable.js
@@ -1,0 +1,22 @@
+import { recentPayment } from './recentPayment';
+
+/**
+ * Return false if any of the conditions fail, meaning the payment
+ * should be unable to be cancelled
+ * @param {string} paymentStatus whether the penalty is PAID or UNPAID
+ * @param {boolean} activePenalty whether the penalty is enabled in the database
+ * @param {float} paymentStartTime when (if) the user began paying the penalty
+ */
+
+export function isCancellable(paymentStatus, activePenalty, paymentStartTime) {
+  if (paymentStatus !== 'UNPAID') {
+    return false;
+  }
+  if (activePenalty !== true) {
+    return false;
+  }
+  if (recentPayment(paymentStartTime)) {
+    return false;
+  }
+  return true;
+}

--- a/src/server/utils/isCancellable.js
+++ b/src/server/utils/isCancellable.js
@@ -1,11 +1,10 @@
 import { recentPayment } from './recentPayment';
 
 /**
- * Return false if any of the conditions fail, meaning the payment
- * should be unable to be cancelled
+ * Return false if any of the conditions fail, meaning the payment should be unable to be cancelled
  * @param {string} paymentStatus whether the penalty is PAID or UNPAID
  * @param {boolean} activePenalty whether the penalty is enabled in the database
- * @param {float} paymentStartTime when (if) the user began paying the penalty
+ * @param {number} paymentStartTime when (if) the user began paying the penalty, will be undefined if doesn't exist
  */
 
 export function isCancellable(paymentStatus, activePenalty, paymentStartTime) {

--- a/test/utils/isCancellable.spec.js
+++ b/test/utils/isCancellable.spec.js
@@ -60,4 +60,14 @@ describe('isCancellable', () => {
       expect(cancellable).to.be.false;
     });
   });
+
+  context('fine is cancellable as there has never been a payment attempt', () => {
+    it.only('returns true', () => {
+      const paymentStatus = 'UNPAID';
+      const activePenalty = true;
+      let paymentStartTime;
+      const cancellable = isCancellable(paymentStatus, activePenalty, paymentStartTime);
+      expect(cancellable).to.be.true;
+    });
+  });
 });

--- a/test/utils/isCancellable.spec.js
+++ b/test/utils/isCancellable.spec.js
@@ -1,0 +1,63 @@
+import sinon from 'sinon';
+import { expect } from 'chai';
+import { isCancellable } from '../../src/server/utils/isCancellable';
+
+function setToday(date) {
+  sinon.useFakeTimers(new Date(date));
+}
+
+describe('isCancellable', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+  context('fine is cancellable', () => {
+    it('returns true', () => {
+      const paymentStatus = 'UNPAID';
+      const activePenalty = true;
+      const paymentStartTime = 1673254800; // 0900 9th January 2023
+      const cancellable = isCancellable(paymentStatus, activePenalty, paymentStartTime);
+      expect(cancellable).to.be.true;
+    });
+  });
+
+  context('fine is not cancellable as already paid', () => {
+    it('returns false', () => {
+      const paymentStatus = 'PAID';
+      const activePenalty = true;
+      const paymentStartTime = 1673254800; // 0900 9th January 2023
+      const cancellable = isCancellable(paymentStatus, activePenalty, paymentStartTime);
+      expect(cancellable).to.be.false;
+    });
+  });
+
+  context('fine is not cancellable as it is inactive', () => {
+    it('returns false', () => {
+      const paymentStatus = 'UNPAID';
+      const activePenalty = false;
+      const paymentStartTime = 1673254800; // 0900 9th January 2023
+      const cancellable = isCancellable(paymentStatus, activePenalty, paymentStartTime);
+      expect(cancellable).to.be.false;
+    });
+  });
+
+  context('fine is not cancellable as payment is in progress', () => {
+    it('returns false', () => {
+      const paymentStatus = 'UNPAID';
+      const activePenalty = true;
+      setToday('2023-01-09 09:05'); // 0905 9th Januay 2023
+      const paymentStartTime = 1673254800; // 0900 9th January 2023
+      const cancellable = isCancellable(paymentStatus, activePenalty, paymentStartTime);
+      expect(cancellable).to.be.false;
+    });
+  });
+
+  context('fine is not cancellable as data is invalid', () => {
+    it('returns false', () => {
+      const paymentStatus = 'TWENTY-NINE';
+      const activePenalty = undefined;
+      const paymentStartTime = 'thirty'; // 0900 9th January 2023
+      const cancellable = isCancellable(paymentStatus, activePenalty, paymentStartTime);
+      expect(cancellable).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
## Description

- Previously, there was no ability to cancel a single penalty - this functionality only existed on group payments.
- Added isCancellable property to penalty object to display cancel fine button.
- Created isCancellable util to contain logic to determine if a fine can be cancelled.
- Added unit tests covering isCancellable returning true or false, plus test with invalid data.
- Added default setting to orphanedPaymentCheckingTime config var.


Related issue: [RSP-1971](https://dvsa.atlassian.net/browse/RSP-1971?atlOrigin=eyJpIjoiZGVmNTk0MjM2ZTQ1NGFlZGJjMjVjODQyZTVmYjc1OWMiLCJwIjoiaiJ9)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
