### PR TITLE
ci: added release-please action to release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,16 +1,36 @@
 name: Release
 
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
 
 env:
   COPY_SOURCE: internal-portal/serveExpressApp/master.zip
   KEY_PATH: internal-portal/serveExpressApp
 
 jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      tag_name: ${{ steps.release.outputs.tag_name }}
+      release_created: ${{ steps.release.outputs.release_created }}
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        id: release
+        with:
+          release-type: node
+          package-name: rsp-internal-portal
 
   promote:
+    if: ${{ needs.release-please.outputs.release_created }}
+    needs: release-please
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
## Description

- Modified workflow to run on pushes to master branch
- Added job to run release-please action
- Modified promote job to require completion of release-please, and only run when release-please outputs a created release (ie when a release PR is merged)


Related issue: [RSP-2178](https://dvsa.atlassian.net/browse/RSP-2178?atlOrigin=eyJpIjoiYTAxZTZmYmM3YTYwNDU0NmFjZmUzZjI0YTBhZWJiMmMiLCJwIjoiaiJ9)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
