### PR TITLE
fix: allow certain payment types to be reversed on the same day

### DIFF
--- a/src/server/services/penalty.service.js
+++ b/src/server/services/penalty.service.js
@@ -57,7 +57,7 @@ export default class PenaltyService {
       isPaymentOverdue: isPaymentOverdue(rawPenalty.paymentCodeDateTime, config.paymentLimitDays()),
       paymentStartTime: rawPenalty.paymentStartTime,
       isCancellable: isCancellable(rawPenalty.paymentStatus, data.Enabled, rawPenalty.paymentStartTime),
-      isReversible: isReversible(rawPenalty.paymentStatus, rawPenalty.paymentDate),
+      isReversible: isReversible(rawPenalty.paymentStatus, rawPenalty.paymentDate, rawPenalty.paymentMethod),
     };
     return penaltyDetails;
   }

--- a/src/server/utils/isReversible.js
+++ b/src/server/utils/isReversible.js
@@ -1,10 +1,13 @@
-export function isReversible(paymentStatus, paymentDate) {
+export function isReversible(paymentStatus, paymentDate, paymentType) {
   if (paymentStatus === 'PAID') {
-    if (paymentDate) {
-      const todaysDate = new Date().setHours(0, 0, 0, 0);
-      const formatPaymentDate = new Date(paymentDate * 1000).setHours(0, 0, 0, 0);
-      return todaysDate > formatPaymentDate;
+    if (paymentType === 'CNP' || paymentType === 'CARD') {
+      if (paymentDate) {
+        const todaysDate = new Date().setHours(0, 0, 0, 0);
+        const formatPaymentDate = new Date(paymentDate * 1000).setHours(0, 0, 0, 0);
+        return todaysDate > formatPaymentDate;
+      }
     }
+    return true;
   }
 
   return false;

--- a/src/server/utils/isReversible.js
+++ b/src/server/utils/isReversible.js
@@ -1,6 +1,6 @@
 export function isReversible(paymentStatus, paymentDate, paymentType) {
   if (paymentStatus === 'PAID') {
-    if (paymentType === 'CNP' || paymentType === 'CARD') {
+    if (paymentType === 'CNP' || paymentType === 'CARD' || paymentType === 'CHEQUE') {
       if (paymentDate) {
         const todaysDate = new Date().setHours(0, 0, 0, 0);
         const formatPaymentDate = new Date(paymentDate * 1000).setHours(0, 0, 0, 0);

--- a/src/server/views/penalty/penaltyDetails.njk
+++ b/src/server/views/penalty/penaltyDetails.njk
@@ -113,7 +113,7 @@
           </table>
         </p>
          {% if not isReversible %}
-          {{ components.notice(text='You cannot reverse this at this time because payments cannot be reversed on the same day they were made. You must wait until the next day to do this.')}}
+          {{ components.notice(text='You cannot reverse this at this time because card and cheque payments cannot be reversed on the same day they were made. You must wait until the next day to do this.')}}
           <br>
         {% endif %}
         {{ components.button(text='Pay another penalty', url='/') }}

--- a/test/utils/isReversible.spec.js
+++ b/test/utils/isReversible.spec.js
@@ -15,7 +15,8 @@ describe('isReversible', () => {
       const paymentStatus = 'PAID';
       const paymentDate = 1674558000; // 1100 24th January 2023
       setToday('2023-01-25');
-      const reversible = isReversible(paymentStatus, paymentDate);
+      const paymentType = 'CNP';
+      const reversible = isReversible(paymentStatus, paymentDate, paymentType);
       expect(reversible).to.be.true;
     });
   });
@@ -25,7 +26,8 @@ describe('isReversible', () => {
       const paymentStatus = 'PAID';
       const paymentDate = 1674558000; // 1100 24th January 2023
       setToday('2023-01-24');
-      const reversible = isReversible(paymentStatus, paymentDate);
+      const paymentType = 'CNP';
+      const reversible = isReversible(paymentStatus, paymentDate, paymentType);
       expect(reversible).to.be.false;
     });
   });
@@ -34,7 +36,8 @@ describe('isReversible', () => {
     it('returns false', () => {
       const paymentStatus = 'UNPAID';
       let paymentDate;
-      const reversible = isReversible(paymentStatus, paymentDate);
+      const paymentType = 'CNP';
+      const reversible = isReversible(paymentStatus, paymentDate, paymentType);
       expect(reversible).to.be.false;
     });
   });
@@ -43,7 +46,8 @@ describe('isReversible', () => {
     it('returns false', () => {
       const paymentStatus = 1562;
       const paymentDate = 'definitely a date';
-      const reversible = isReversible(paymentStatus, paymentDate);
+      const paymentType = 'CNP';
+      const reversible = isReversible(paymentStatus, paymentDate, paymentType);
       expect(reversible).to.be.false;
     });
   });
@@ -52,8 +56,39 @@ describe('isReversible', () => {
     it('returns false', () => {
       const paymentStatus = 'PAID';
       const paymentDate = 4833172820; // 1200 27th February 2123
-      const reversible = isReversible(paymentStatus, paymentDate);
+      const paymentType = 'CNP';
+      const reversible = isReversible(paymentStatus, paymentDate, paymentType);
       expect(reversible).to.be.false;
+    });
+  });
+
+  context('fine is not reversible as payment type is cheque', () => {
+    it('returns false', () => {
+      const paymentStatus = 'PAID';
+      const paymentDate = 4833172820; // 1200 27th February 2123
+      const paymentType = 'CHEQUE';
+      const reversible = isReversible(paymentStatus, paymentDate, paymentType);
+      expect(reversible).to.be.false;
+    });
+  });
+
+  context('fine is reversible as payment type is cash', () => {
+    it('returns true', () => {
+      const paymentStatus = 'PAID';
+      const paymentDate = 4833172820; // 1200 27th February 2123
+      const paymentType = 'CASH';
+      const reversible = isReversible(paymentStatus, paymentDate, paymentType);
+      expect(reversible).to.be.true;
+    });
+  });
+
+  context('fine is reversible as payment type is postal order', () => {
+    it('returns true', () => {
+      const paymentStatus = 'PAID';
+      const paymentDate = 4833172820; // 1200 27th February 2123
+      const paymentType = 'POSTAL';
+      const reversible = isReversible(paymentStatus, paymentDate, paymentType);
+      expect(reversible).to.be.true;
     });
   });
 });


### PR DESCRIPTION
## Description

- When the reversible flow was introduced, there was no checking on the type of payments, despite the fact only card and cheque payments must wait until the next working day to reverse
- To fix, an if check has been added to the reversible utility, which checks if the payment type is CNP, CARD or CHEQUE
- paymentType is now passed in to the reversible function too to allow for checking
- Updated view to inform user that card or cheque payments cannot be reversed on the same day
- Added unit tests to cover each payment type being sent for reversal

Related issue: [RSP-2195](https://dvsa.atlassian.net/browse/RSP-2195?atlOrigin=eyJpIjoiOGIzODE2MjYwYzhiNDVkZjhmNmM3M2MzNzliZjc5N2QiLCJwIjoiaiJ9)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
