### PR TITLE
feature: Added data-testid around unable to reverse payment message

### DIFF
--- a/src/server/views/penalty/penaltyDetails.njk
+++ b/src/server/views/penalty/penaltyDetails.njk
@@ -113,7 +113,9 @@
           </table>
         </p>
          {% if not isReversible %}
+         <div class "notReversible" id="notReversible" data-testid="notReversible"
           {{ components.notice(text='You cannot reverse this at this time because card and cheque payments cannot be reversed on the same day they were made. You must wait until the next day to do this.')}}
+         </div>
           <br>
         {% endif %}
         {{ components.button(text='Pay another penalty', url='/') }}


### PR DESCRIPTION
## Description


Added a data-testid tag around the message which is is displayed when reverse a payment can not be done. This will help the playwright E2E test suite to select the element. 


Related issue: [RSP-2204](https://dvsa.atlassian.net/jira/software/c/projects/RSP/boards/830?modal=detail&selectedIssue=RSP-2204)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
