### PR TITLE
feat: added Pay another penalty button to group payments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rsp-internal-portal",
-  "version": "1.17.2",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rsp-internal-portal",
-      "version": "1.17.2",
+      "version": "3.0.0",
       "license": "ISC",
       "dependencies": {
         "@babel/polyfill": "^7.4.0",

--- a/src/server/views/penalty/penaltyGroupSummary.njk
+++ b/src/server/views/penalty/penaltyGroupSummary.njk
@@ -184,7 +184,10 @@
           </div>
         {% endif %}
       {% endfor %}
+      <br>
+      {{ components.button(text='Pay another penalty', url='/') }}
     {%- endcall %}
+
 
     {% if isCancellable %}
       {% call components.columnOneThird() %}


### PR DESCRIPTION
## Description

- There was an issue where a button was missing from the group penalty payment confirmation screen, which would've allowed the user to navigate back to the home page to pay more fines, if desired.
- This PR adds that button, improving accessibility and user experience.

Related issue: [RSP-2190](https://dvsa.atlassian.net/browse/RSP-2190?atlOrigin=eyJpIjoiM2ZmYWQzNTA1ZjY1NDhmZmI4MjZjYTc0OWQxY2MxOWEiLCJwIjoiaiJ9)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
