### PR TITLE
fix: Allow all on CSP to fix prod issue

### DIFF
--- a/src/server/app.js
+++ b/src/server/app.js
@@ -60,7 +60,8 @@ export default async () => {
 
   app.use(helmet.contentSecurityPolicy({
     directives: {
-      defaultSrc: ["'self'", assetsUrl],
+      defaultSrc: ['*'],
+      // defaultSrc: ["'self'", assetsUrl],
       formAction: ['*'],
       scriptSrc: [
         assetsUrl,


### PR DESCRIPTION
## Description

- Currently seeing imperva blocking pages when it can't render JS bot check page
- Set CSP to allow all

Related issue: n/a

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
