### PR TITLE
feat: New env var to allow payment for overdue payments

### DIFF
--- a/src/server/config.js
+++ b/src/server/config.js
@@ -28,6 +28,7 @@ const configMetadata = {
   urlRoot: 'URL_ROOT',
   views: 'VIEWS',
   paymentLimitDays: 'PAYMENT_LIMIT_DAYS',
+  featureBypassExpiryDate: 'FEATURE_BYPASS_EXPIRY_DATE',
 };
 
 let configuration = {};
@@ -159,11 +160,15 @@ function views() {
 
 function paymentLimitDays() {
   const defaultDays = 42;
-  const days = configuration[configMetadata.paymentLimitDays];
+  const days = process.env[configMetadata.paymentLimitDays];
   if (days) {
     return Number.isNaN(Number(days)) ? defaultDays : Number(days);
   }
   return defaultDays;
+}
+
+function featureBypassExpiryDate() {
+  return process.env[configMetadata.featureBypassExpiryDate] === 'true';
 }
 
 const config = {
@@ -191,6 +196,7 @@ const config = {
   urlRoot,
   views,
   paymentLimitDays,
+  featureBypassExpiryDate,
 };
 
 export default config;

--- a/src/server/services/penalty.service.js
+++ b/src/server/services/penalty.service.js
@@ -54,7 +54,7 @@ export default class PenaltyService {
       paymentCodeIssueDateTime: rawPenalty.paymentCodeDateTime
         ? moment.unix(rawPenalty.paymentCodeDateTime).format(MOMENT_DATE_TIME_FORMAT)
         : undefined,
-      isPaymentOverdue: isPaymentOverdue(rawPenalty.paymentCodeDateTime, config.paymentLimitDays()),
+      isPaymentOverdue: isPaymentOverdue(rawPenalty.paymentCodeDateTime, config.paymentLimitDays(), config.featureBypassExpiryDate()),
       paymentStartTime: rawPenalty.paymentStartTime,
       isCancellable: isCancellable(rawPenalty.paymentStatus, data.Enabled, rawPenalty.paymentStartTime),
       isReversible: isReversible(rawPenalty.paymentStatus, rawPenalty.paymentDate, rawPenalty.paymentMethod),

--- a/src/server/services/penaltyGroup.service.js
+++ b/src/server/services/penaltyGroup.service.js
@@ -51,7 +51,7 @@ export default class PenaltyGroupService {
         registrationNumber: VehicleRegistration,
         location: Location,
         dateTime: moment.unix(Timestamp).format(MOMENT_DATE_TIME_FORMAT),
-        isPaymentOverdue: isPaymentOverdue(Timestamp, config.paymentLimitDays()),
+        isPaymentOverdue: isPaymentOverdue(Timestamp, config.paymentLimitDays(), config.featureBypassExpiryDate()),
         amount: TotalAmount,
         enabled: Enabled,
         splitAmounts,
@@ -102,7 +102,7 @@ export default class PenaltyGroupService {
       penaltyType: type,
       totalAmount: pensOfType.reduce((total, pen) => total + pen.Value.penaltyAmount, 0),
       paymentStatus: parsedPenalties.every((p) => p.status === 'PAID') ? 'PAID' : 'UNPAID',
-      isPaymentOverdue: isPaymentOverdue(Timestamp, config.paymentLimitDays()),
+      isPaymentOverdue: isPaymentOverdue(Timestamp, config.paymentLimitDays(), config.featureBypassExpiryDate()),
     };
   }
 

--- a/src/server/utils/isPaymentOverdue.js
+++ b/src/server/utils/isPaymentOverdue.js
@@ -4,8 +4,12 @@ import moment from 'moment';
  * Return false if the payment is still within the valid payment time limit
  * @param {string} dateTime date and time of the penalty. Expected format: 1661855255
  * @param {int} daysLimit number representing how many days from the date of the penalty the fine can be paid
+ * @param {boolean} featureBypassExpiryDate Feature toggle, when true users can accept payment at ANY TIME after the penalty and skip date checking of penalty
  */
-export default function isPaymentOverdue(dateTime, daysLimit) {
+export default function isPaymentOverdue(dateTime, daysLimit, featureBypassExpiryDate = false) {
+  if (featureBypassExpiryDate) {
+    return false;
+  }
   const penaltyDateTime = moment.unix(dateTime);
   if (!penaltyDateTime.isValid()) {
     return true;

--- a/test/utils/isPaymentOverdue.spec.js
+++ b/test/utils/isPaymentOverdue.spec.js
@@ -57,4 +57,24 @@ describe('isPaymentOverdue', () => {
       expect(isOverdue).to.be.true;
     });
   });
+
+  context('Bypass expiry date feature toggle is enabled', () => {
+    it('returns false for an overdue payment', () => {
+      const dateOfPenalty = '1656667800'; // unix second time stamp 1st July 2022
+      setToday('2022-08-19 10:30'); // 19th August 2022
+      const daysToPayLimit = 42;
+      const isOverdue = isPaymentOverdue(dateOfPenalty, daysToPayLimit, true);
+      expect(isOverdue).to.be.false;
+    });
+  });
+
+  context('Bypass expiry date feature toggle is disabled', () => {
+    it('returns true for an overdue payment', () => {
+      const dateOfPenalty = '1656667800'; // unix second time stamp 1st July 2022
+      setToday('2022-08-19 10:30'); // 19th August 2022
+      const daysToPayLimit = 42;
+      const isOverdue = isPaymentOverdue(dateOfPenalty, daysToPayLimit, false);
+      expect(isOverdue).to.be.true;
+    });
+  });
 });


### PR DESCRIPTION
## Description

- New Feature Toggle environment variable
- If the feature toggle is true, the penalty is never marked as overdue so payment can be taken
- Updated `isPaymentOverdue` check to always return false if the feature toggle is set to true
- New unit tests to test feature toggle check
- Updated config to use variables from environment (process.env) instead of secrets manager

Related issue: [RSP-2242](https://dvsa.atlassian.net/browse/RSP-2242)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
