### PR TITLE
fix: Updated group payment logging

### DIFF
--- a/src/server/controllers/paymentCode.controller.js
+++ b/src/server/controllers/paymentCode.controller.js
@@ -92,17 +92,20 @@ export const getPenaltyGroupBreakdownForType = [
 
 export const cancelPaymentCode = async (req, res) => {
   const paymentCode = req.params.payment_code;
-  logInfo('CancelPaymentCode', {
+  const logMessage = {
     userEmail: req.session.rsp_user.email,
     userRole: req.session.rsp_user_role,
     paymentCode,
-  });
+  };
   try {
     await penaltyGroupService.cancel(paymentCode);
-    logInfo('cancelPaymentCodeSuccess', { paymentCode });
+    logInfo('cancelPenaltyGroupSuccess', logMessage);
     res.redirect(`${config.urlRoot()}/payment-code/${paymentCode}`);
   } catch (error) {
-    logError('cancelPaymentCodeError', { paymentCode, error });
+    logError('cancelPenaltyGroupError', {
+      ...logMessage,
+      error: error.message,
+    });
     res.redirect(`${config.urlRoot()}/payment-code/${paymentCode}?cancellation=failed`);
   }
 };

--- a/src/server/controllers/penalty.controller.js
+++ b/src/server/controllers/penalty.controller.js
@@ -45,14 +45,15 @@ export const cancelPenalty = async (req, res) => {
   const penaltyId = req.params.penalty_id;
   const logMessage = {
     userEmail: req.session.rsp_user.email,
+    userRole: req.session.rsp_user_role,
     penaltyId,
   };
   try {
     await penaltyService.cancel(penaltyId);
-    logInfo('CancelPenaltySuccess', logMessage);
+    logInfo('cancelPenaltySuccess', logMessage);
     res.redirect(`${config.urlRoot()}/penalty/${penaltyId}`);
   } catch (error) {
-    logError('CancelPenaltyError', {
+    logError('cancelPenaltyError', {
       ...logMessage,
       error: error.message,
     });


### PR DESCRIPTION
## Description

- Previously, in group penalties cancellation, a log would be made when the attempt was made, followed by a log with either a success or error.
- This diverges from single penalty cancellation, where a log is only made when the attempt succeeds or fails.
- Group payments have been updated to reflect this, logging out the userEmail, userRole and paymentCode, plus an error message in the case of an error.
- Single payment cancellation now also logs out userRole.
- Log titles have been updated to better reflect what they do (cancelPaymentCode -> cancelPenaltyGroup) and camel-casing has been properly applied.

Related issue: [RSP-2238](https://dvsa.atlassian.net/browse/RSP-2238)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
