### PR TITLE
feat: Restrict CSP for self and assets urls only

### DIFF
--- a/src/server/app.js
+++ b/src/server/app.js
@@ -60,15 +60,13 @@ export default async () => {
 
   app.use(helmet.contentSecurityPolicy({
     directives: {
-      defaultSrc: ['*'],
-      // defaultSrc: ["'self'", assetsUrl],
+      defaultSrc: ["'self'", assetsUrl],
       formAction: ['*'],
       scriptSrc: [
         assetsUrl,
         'https://www.googletagmanager.com/',
         'https://www.google-analytics.com/',
         'https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/',
-        '*',
       ],
       fontSrc: ['data:'],
       imgSrc: [


### PR DESCRIPTION
## Description

- The CSP was relaxed in an attempt to fix an issue with Imperva during release 4
- This is not required and should be restriced again

Related issue: [RSP-2237](https://dvsa.atlassian.net/browse/RSP-2237)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
