### PR TITLE
ci: updated workflow to add new tags, fixed faulty if statement

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,13 +8,13 @@ on:
 jobs:
 
   lint:
-    uses: dvsa/.github/.github/workflows/nodejs-lint.yaml@v2.3
+    uses: dvsa/.github/.github/workflows/nodejs-lint.yaml@v3.1.0
 
   test:
-    uses: dvsa/.github/.github/workflows/nodejs-test.yaml@v2.3
+    uses: dvsa/.github/.github/workflows/nodejs-test.yaml@v3.1.0
 
   security:
-    uses: dvsa/.github/.github/workflows/nodejs-security.yaml@v2.3
+    uses: dvsa/.github/.github/workflows/nodejs-security.yaml@v3.1.0
     with:
       args: '--all-projects'
     secrets:
@@ -38,38 +38,40 @@ jobs:
           echo "::set-output name=archive_name::${PRETTY_BRANCH_NAME}"
 
   build:
-    if: startsWith( github.ref, 'refs/heads/feature/') || startsWith( github.ref, 'refs/heads/fix/') || ${{ github.ref_name == 'master' }}
-    uses: dvsa/.github/.github/workflows/nodejs-build.yaml@v2.3
+    uses: dvsa/.github/.github/workflows/nodejs-build.yaml@v3.1.0
     with:
-      upload_artifact: true
+      upload-artifact: true
 
   upload-s3:
-    if: startsWith( github.ref, 'refs/heads/feature/') || startsWith( github.ref, 'refs/heads/fix/') || ${{ github.ref_name == 'master' }}
-    uses: dvsa/.github/.github/workflows/upload-to-s3.yaml@v2.3
+    if: startsWith(github.ref, 'refs/heads/feat/') || startsWith(github.ref, 'refs/heads/feature/') || startsWith(github.ref, 'refs/heads/fix/') || startsWith(github.ref, 'refs/heads/master')
+    uses: dvsa/.github/.github/workflows/upload-to-s3.yaml@v3.1.0
     needs: [ build-names, build ]
     with:
       environment: nonprod
-      short_commit: ${{ needs.build-names.outputs.short_sha }}
+      short-commit: ${{ needs.build-names.outputs.short_sha }}
+      optional-tags: lifecycle_subject=${{ startsWith(github.ref, 'refs/heads/feat/') || startsWith(github.ref, 'refs/heads/feature/') || startsWith(github.ref, 'refs/heads/fix/') }}
       artifact: package.zip
-      bucket_key: internal-portal/serveExpressApp/${{ needs.build-names.outputs.archive_name }}.zip
+      bucket-key: internal-portal/serveExpressApp/${{ needs.build-names.outputs.archive_name }}.zip
     permissions:
       id-token: write
     secrets:
+      AWS_ROLE_TO_ASSUME_ARN: ${{ secrets.AWS_ROLE_TO_ASSUME_ARN }}
       AWS_ACCOUNT: ${{ secrets.RSP_AWS_ACCOUNT }}
       AWS_REGION: ${{ secrets.RSP_AWS_REGION }}
       BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
 
   update-lambda-code:
     if: ${{ github.ref_name == github.event.repository.default_branch }}
-    uses: dvsa/.github/.github/workflows/update-lambda-function.yaml@v2.3
+    uses: dvsa/.github/.github/workflows/update-lambda-function.yaml@v3.1.0
     needs: [ build-names, build, upload-s3 ]
     with:
       environment: nonprod
-      lambda_function_name: rsp-nonprod-apis-internal-portal-serveExpressApp
-      bucket_key: internal-portal/serveExpressApp/${{ needs.build-names.outputs.archive_name }}.zip
+      lambda-function-name: rsp-nonprod-apis-internal-portal-serveExpressApp
+      bucket-key: internal-portal/serveExpressApp/${{ needs.build-names.outputs.archive_name }}.zip
     permissions:
       id-token: write
     secrets:
+      AWS_ROLE_TO_ASSUME_ARN: ${{ secrets.AWS_ROLE_TO_ASSUME_ARN }}
       AWS_ACCOUNT: ${{ secrets.RSP_AWS_ACCOUNT }}
       AWS_REGION: ${{ secrets.RSP_AWS_REGION }}
       BUCKET_NAME: ${{ secrets.BUCKET_NAME }}


### PR DESCRIPTION
## Description

- As part of the work for adding a lifecycle policy to RSP S3 bucket, a requirement surfaced for tagging objects uploaded to S3 based on their type (feat, fix, master).
- This incorporates the updated upload to s3 action.
- An optional tag is passed in, called lifecycle-subject, the value of which comes from an expression evaluating github refs
- It also became apparent that a previously existing check was not working, which should have prevented builds being uploaded to s3 if they did not start with feature or fix.
- This has been fixed, and expanded to include feat (shorthand for feature).

Related issue: [RSP-2091](https://dvsa.atlassian.net/browse/RSP-2091)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
